### PR TITLE
Initialize product comparison UI with Vite React

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# whey-comparator
+# Whey Comparator
+
+Application front-end construite avec Vite + React + TypeScript pour comparer des compléments (whey et créatine).
+
+## Scripts
+
+```bash
+npm install
+npm run dev
+npm run build
+```
+
+## Fonctionnalités
+
+- Filtres avancés par marque, type de produit et plage de prix.
+- Comparaison dynamique de 2 à 4 produits avec stockage de l'état via Zustand.
+- Récupération des données produits avec React Query et indicateurs clés (KPIs).
+- Skeleton loaders et design responsive avec Tailwind CSS.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: {
+        ...js.environments.browser.globals,
+      },
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Whey Comparator</title>
+  </head>
+  <body class="bg-slate-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "whey-comparator",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.45.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.10"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+
+import { ProductFiltersSidebar } from './components/ProductFiltersSidebar';
+import { KpiSummaryBar } from './components/KpiSummaryBar';
+import { ProductComparisonTable } from './components/ProductComparisonTable';
+import { useProducts } from './hooks/useProducts';
+import { selectFilters, selectSelectedProductIds, useProductSelectionStore } from './store/productSelectionStore';
+
+export default function App() {
+  const { data: products = [], isLoading } = useProducts();
+  const filters = useProductSelectionStore(useShallow(selectFilters));
+  const selectedProductIds = useProductSelectionStore(selectSelectedProductIds);
+
+  const filteredProducts = useMemo(() => {
+    return products.filter((product) => {
+      const matchesBrand =
+        filters.selectedBrands.length === 0 || filters.selectedBrands.includes(product.brand);
+      const matchesType = filters.selectedTypes.length === 0 || filters.selectedTypes.includes(product.type);
+      const [minPrice, maxPrice] = filters.priceRange;
+      const matchesPrice = product.price >= minPrice && product.price <= maxPrice;
+      return matchesBrand && matchesType && matchesPrice;
+    });
+  }, [filters.selectedBrands, filters.selectedTypes, filters.priceRange, products]);
+
+  const selectedProducts = useMemo(
+    () => products.filter((product) => selectedProductIds.includes(product.id)),
+    [products, selectedProductIds],
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100">
+      <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 pb-12 pt-10 lg:px-8">
+        <header className="space-y-3">
+          <span className="inline-flex items-center rounded-full bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700">
+            Comparateur intelligent
+          </span>
+          <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">Comparez vos compléments favoris</h1>
+          <p className="max-w-2xl text-base text-slate-600">
+            Filtrez par marque, type et budget pour construire un comparatif entre deux et quatre produits.
+            Analysez les KPIs clés comme le prix par 100 g de protéine pour trouver le meilleur rapport
+            qualité/prix.
+          </p>
+        </header>
+
+        <KpiSummaryBar selectedProducts={selectedProducts} isLoading={isLoading} />
+
+        <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
+          <ProductFiltersSidebar
+            allProducts={products}
+            filteredProducts={filteredProducts}
+            isLoading={isLoading}
+          />
+          <ProductComparisonTable products={selectedProducts} isLoading={isLoading} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/KpiSummaryBar.tsx
+++ b/src/components/KpiSummaryBar.tsx
@@ -1,0 +1,125 @@
+import { useMemo } from 'react';
+
+import type { Product } from '../data/products';
+
+interface KpiSummaryBarProps {
+  selectedProducts: Product[];
+  isLoading: boolean;
+}
+
+interface KpiCardProps {
+  label: string;
+  value: string;
+  helper?: string;
+}
+
+const KpiCard = ({ label, value, helper }: KpiCardProps) => (
+  <div className="rounded-xl border border-slate-200 bg-white/60 p-4">
+    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</p>
+    <p className="mt-2 text-2xl font-semibold text-slate-900">{value}</p>
+    {helper ? <p className="mt-1 text-xs text-slate-500">{helper}</p> : null}
+  </div>
+);
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 2,
+  }).format(value);
+
+export const KpiSummaryBar = ({ selectedProducts, isLoading }: KpiSummaryBarProps) => {
+  const metrics = useMemo(() => {
+    if (selectedProducts.length === 0) {
+      return null;
+    }
+
+    const totalPrice = selectedProducts.reduce((sum, product) => sum + product.price, 0);
+    const averagePrice = totalPrice / selectedProducts.length;
+
+    const proteinBasedProducts = selectedProducts.filter((product) => product.proteinPerServing > 0);
+    const pricePer100g = proteinBasedProducts.map((product) => {
+      const totalProtein = product.proteinPerServing * product.servings;
+      return totalProtein > 0 ? (product.price / totalProtein) * 100 : Number.POSITIVE_INFINITY;
+    });
+
+    const averagePricePer100g =
+      pricePer100g.length > 0
+        ? pricePer100g.reduce((sum, value) => sum + value, 0) / pricePer100g.length
+        : undefined;
+
+    const bestValueProduct = proteinBasedProducts.reduce<
+      | { product: Product; value: number }
+      | undefined
+    >((best, product) => {
+      const totalProtein = product.proteinPerServing * product.servings;
+      if (totalProtein === 0) {
+        return best;
+      }
+      const value = (product.price / totalProtein) * 100;
+      if (!best || value < best.value) {
+        return { product, value };
+      }
+      return best;
+    }, undefined);
+
+    const averageRating =
+      selectedProducts.reduce((sum, product) => sum + product.rating, 0) / selectedProducts.length;
+
+    return {
+      averagePrice,
+      averagePricePer100g,
+      bestValueProduct,
+      averageRating,
+    };
+  }, [selectedProducts]);
+
+  if (isLoading) {
+    return (
+      <section className="grid gap-4 rounded-2xl bg-white/80 p-6 shadow-sm sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="h-24 animate-pulse rounded-xl bg-slate-200" />
+        ))}
+      </section>
+    );
+  }
+
+  if (!metrics) {
+    return (
+      <section className="rounded-2xl bg-white/80 p-6 text-center shadow-sm">
+        <p className="text-sm text-slate-500">
+          Sélectionnez des produits pour voir les indicateurs clés (KPIs).
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="grid gap-4 rounded-2xl bg-white/80 p-6 shadow-sm sm:grid-cols-2 lg:grid-cols-4">
+      <KpiCard label="Prix moyen" value={formatCurrency(metrics.averagePrice)} />
+      <KpiCard
+        label="Prix moyen / 100 g de protéine"
+        value={
+          metrics.averagePricePer100g
+            ? `${metrics.averagePricePer100g.toFixed(2)} €`
+            : 'N/A'
+        }
+        helper={
+          metrics.averagePricePer100g
+            ? 'Basé sur les produits riches en protéines sélectionnés.'
+            : 'Aucun produit protéiné sélectionné.'
+        }
+      />
+      <KpiCard
+        label="Meilleur rapport qualité/prix"
+        value={metrics.bestValueProduct ? metrics.bestValueProduct.product.name : 'N/A'}
+        helper={
+          metrics.bestValueProduct
+            ? `${metrics.bestValueProduct.value.toFixed(2)} € / 100 g de protéine`
+            : 'Sélectionnez au moins une whey.'
+        }
+      />
+      <KpiCard label="Note moyenne" value={`${metrics.averageRating.toFixed(1)} / 5`} />
+    </section>
+  );
+};

--- a/src/components/ProductComparisonTable.tsx
+++ b/src/components/ProductComparisonTable.tsx
@@ -1,0 +1,173 @@
+import { useMemo } from 'react';
+
+import type { Product } from '../data/products';
+import { useProductSelectionStore } from '../store/productSelectionStore';
+
+interface ProductComparisonTableProps {
+  products: Product[];
+  isLoading: boolean;
+}
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const formatNumber = (value: number, options?: Intl.NumberFormatOptions) =>
+  new Intl.NumberFormat('fr-FR', {
+    maximumFractionDigits: 1,
+    ...options,
+  }).format(value);
+
+export const ProductComparisonTable = ({ products, isLoading }: ProductComparisonTableProps) => {
+  const toggleProductSelection = useProductSelectionStore((state) => state.toggleProductSelection);
+
+  const rows = useMemo(
+    () =>
+      [
+        {
+          label: 'Marque',
+          render: (product: Product) => product.brand,
+        },
+        {
+          label: 'Type',
+          render: (product: Product) => (product.type === 'whey' ? 'Whey' : 'Créatine'),
+        },
+        {
+          label: 'Prix',
+          render: (product: Product) => formatCurrency(product.price),
+        },
+        {
+          label: 'Portions',
+          render: (product: Product) => formatNumber(product.servings, { maximumFractionDigits: 0 }),
+        },
+        {
+          label: 'Protéines / portion',
+          render: (product: Product) =>
+            product.proteinPerServing > 0 ? `${formatNumber(product.proteinPerServing)} g` : 'N/A',
+        },
+        {
+          label: 'Créatine / portion',
+          render: (product: Product) =>
+            product.creatinePerServing ? `${formatNumber(product.creatinePerServing)} g` : 'N/A',
+        },
+        {
+          label: 'Prix / portion',
+          render: (product: Product) => formatCurrency(product.price / product.servings),
+        },
+        {
+          label: 'Taille du pot',
+          render: (product: Product) => `${formatNumber(product.sizeGrams, { maximumFractionDigits: 0 })} g`,
+        },
+        {
+          label: 'Arôme',
+          render: (product: Product) => product.flavor,
+        },
+        {
+          label: 'Note moyenne',
+          render: (product: Product) => `${formatNumber(product.rating)} / 5`,
+        },
+      ],
+    [],
+  );
+
+  if (isLoading) {
+    return (
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <div className="mb-4 h-6 w-48 animate-pulse rounded bg-slate-200" />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-28 animate-pulse rounded-xl bg-slate-200" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (products.length < 2) {
+    return (
+      <section className="rounded-2xl bg-white p-6 text-center shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Choisissez au moins 2 produits</h2>
+        <p className="mt-2 text-sm text-slate-500">
+          Utilisez la colonne de gauche pour sélectionner entre deux et quatre produits à comparer.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Comparatif des produits</h2>
+          <p className="text-sm text-slate-500">Colonnes dynamiques selon votre sélection.</p>
+        </div>
+      </div>
+
+      <div className="mt-6 overflow-x-auto">
+        <table className="min-w-full text-left text-sm text-slate-700">
+          <thead>
+            <tr>
+              <th className="w-48 border-b border-slate-200 pb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Critère
+              </th>
+              {products.map((product) => (
+                <th
+                  key={product.id}
+                  className="border-b border-slate-200 pb-3 text-left text-base font-semibold text-slate-900"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div>{product.name}</div>
+                      <div className="text-xs text-slate-500">{product.brand}</div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => toggleProductSelection(product.id)}
+                      className="text-xs font-medium text-primary-600 hover:text-primary-700"
+                    >
+                      Retirer
+                    </button>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.label} className="border-b border-slate-100 last:border-0">
+                <th className="py-4 text-xs font-semibold uppercase tracking-wide text-slate-500">{row.label}</th>
+                {products.map((product) => (
+                  <td key={product.id} className="py-4 pr-6">
+                    {row.render(product)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+            <tr className="border-b border-slate-100">
+              <th className="py-4 text-xs font-semibold uppercase tracking-wide text-slate-500">Lien</th>
+              {products.map((product) => (
+                <td key={product.id} className="py-4">
+                  {product.link ? (
+                    <a
+                      href={product.link}
+                      className="text-sm font-medium text-primary-600 hover:text-primary-700"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Voir le produit
+                    </a>
+                  ) : (
+                    <span className="text-sm text-slate-400">Non renseigné</span>
+                  )}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/src/components/ProductFiltersSidebar.tsx
+++ b/src/components/ProductFiltersSidebar.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo } from 'react';
+import type { ChangeEvent } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+
+import type { Product, ProductType } from '../data/products';
+import {
+  selectFilters,
+  selectSelectedProductIds,
+  useProductSelectionStore,
+} from '../store/productSelectionStore';
+
+interface ProductFiltersSidebarProps {
+  allProducts: Product[];
+  filteredProducts: Product[];
+  isLoading: boolean;
+}
+
+const typeLabels: Record<ProductType, string> = {
+  whey: 'Whey',
+  creatine: 'Créatine',
+};
+
+export const ProductFiltersSidebar = ({
+  allProducts,
+  filteredProducts,
+  isLoading,
+}: ProductFiltersSidebarProps) => {
+  const { selectedBrands, selectedTypes, priceBounds, priceRange } =
+    useProductSelectionStore(useShallow(selectFilters));
+  const selectedProductIds = useProductSelectionStore(selectSelectedProductIds);
+  const { setSelectedBrands, setSelectedTypes, setPriceBounds, setPriceRange, toggleProductSelection } =
+    useProductSelectionStore(
+      useShallow((state) => ({
+        setSelectedBrands: state.setSelectedBrands,
+        setSelectedTypes: state.setSelectedTypes,
+        setPriceBounds: state.setPriceBounds,
+        setPriceRange: state.setPriceRange,
+        toggleProductSelection: state.toggleProductSelection,
+      })),
+    );
+
+  const brandOptions = useMemo(
+    () => Array.from(new Set(allProducts.map((product) => product.brand))).sort(),
+    [allProducts],
+  );
+
+  useEffect(() => {
+    if (!isLoading && allProducts.length > 0) {
+      const min = Math.min(...allProducts.map((product) => product.price));
+      const max = Math.max(...allProducts.map((product) => product.price));
+      const nextBounds: [number, number] = [Math.floor(min), Math.ceil(max)];
+
+      if (nextBounds[0] !== priceBounds[0] || nextBounds[1] !== priceBounds[1]) {
+        setPriceBounds(nextBounds);
+      }
+    }
+  }, [allProducts, isLoading, priceBounds, setPriceBounds]);
+
+  const handleBrandToggle = (brand: string) => {
+    if (selectedBrands.includes(brand)) {
+      setSelectedBrands(selectedBrands.filter((value) => value !== brand));
+    } else {
+      setSelectedBrands([...selectedBrands, brand]);
+    }
+  };
+
+  const handleTypeToggle = (type: ProductType) => {
+    if (selectedTypes.includes(type)) {
+      setSelectedTypes(selectedTypes.filter((value) => value !== type));
+    } else {
+      setSelectedTypes([...selectedTypes, type]);
+    }
+  };
+
+  const handleMinPriceChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextMin = Number.parseFloat(event.target.value);
+    setPriceRange([Number.isNaN(nextMin) ? priceBounds[0] : nextMin, priceRange[1]]);
+  };
+
+  const handleMaxPriceChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextMax = Number.parseFloat(event.target.value);
+    setPriceRange([priceRange[0], Number.isNaN(nextMax) ? priceBounds[1] : nextMax]);
+  };
+
+  const filteredSelection = useMemo(
+    () =>
+      filteredProducts.map((product) => ({
+        product,
+        disabled:
+          selectedProductIds.length >= 4 && !selectedProductIds.includes(product.id),
+      })),
+    [filteredProducts, selectedProductIds],
+  );
+
+  if (isLoading && allProducts.length === 0) {
+    return (
+      <aside className="space-y-6 rounded-2xl bg-white p-6 shadow-sm">
+        <div className="space-y-4">
+          <div className="h-5 w-32 animate-pulse rounded bg-slate-200" />
+          <div className="space-y-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="h-4 w-full animate-pulse rounded bg-slate-200" />
+            ))}
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div className="h-5 w-40 animate-pulse rounded bg-slate-200" />
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="h-4 w-3/4 animate-pulse rounded bg-slate-200" />
+            ))}
+          </div>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="space-y-6 rounded-2xl bg-white p-6 shadow-sm">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-900">Filtres</h2>
+        <p className="text-sm text-slate-500">Affinez la liste pour trouver les produits à comparer.</p>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Marques</h3>
+        <div className="space-y-2">
+          {brandOptions.map((brand) => (
+            <label key={brand} className="flex items-center gap-2 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={selectedBrands.includes(brand)}
+                onChange={() => handleBrandToggle(brand)}
+                className="h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+              />
+              {brand}
+            </label>
+          ))}
+          {brandOptions.length === 0 && <p className="text-sm text-slate-500">Aucune marque disponible.</p>}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Type</h3>
+        <div className="space-y-2">
+          {(['whey', 'creatine'] as ProductType[]).map((type) => (
+            <label key={type} className="flex items-center gap-2 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={selectedTypes.includes(type)}
+                onChange={() => handleTypeToggle(type)}
+                className="h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+              />
+              {typeLabels[type]}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Prix (€)</h3>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs uppercase text-slate-400">Min</label>
+            <input
+              type="number"
+              className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              value={priceRange[0]}
+              min={priceBounds[0]}
+              max={priceRange[1]}
+              onChange={handleMinPriceChange}
+            />
+          </div>
+          <div>
+            <label className="text-xs uppercase text-slate-400">Max</label>
+            <input
+              type="number"
+              className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              value={priceRange[1]}
+              min={priceRange[0]}
+              max={priceBounds[1]}
+              onChange={handleMaxPriceChange}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Sélection ({selectedProductIds.length}/4)</h3>
+          <span className="text-xs text-slate-400">Comparer 2 à 4 produits</span>
+        </div>
+        <div className="space-y-2">
+          {filteredSelection.map(({ product, disabled }) => (
+            <label
+              key={product.id}
+              className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
+            >
+              <div className="flex flex-col">
+                <span className="font-medium text-slate-900">{product.name}</span>
+                <span className="text-xs text-slate-500">
+                  {product.brand} • {typeLabels[product.type]}
+                </span>
+              </div>
+              <input
+                type="checkbox"
+                checked={selectedProductIds.includes(product.id)}
+                disabled={disabled}
+                onChange={() => toggleProductSelection(product.id)}
+                className="h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500 disabled:opacity-40"
+              />
+            </label>
+          ))}
+          {!isLoading && filteredSelection.length === 0 && (
+            <p className="text-sm text-slate-500">Aucun produit ne correspond aux filtres.</p>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+};

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,0 +1,99 @@
+export type ProductType = 'whey' | 'creatine';
+
+export interface Product {
+  id: string;
+  name: string;
+  brand: string;
+  type: ProductType;
+  price: number; // €
+  sizeGrams: number;
+  proteinPerServing: number; // g
+  creatinePerServing?: number; // g
+  servings: number;
+  flavor: string;
+  rating: number; // 0-5
+  link?: string;
+}
+
+export const products: Product[] = [
+  {
+    id: 'iso-elite-vanilla',
+    name: 'Iso Elite Vanilla',
+    brand: 'NutriFuel',
+    type: 'whey',
+    price: 39.9,
+    sizeGrams: 900,
+    proteinPerServing: 27,
+    servings: 30,
+    flavor: 'Vanille',
+    rating: 4.6,
+    link: '#',
+  },
+  {
+    id: 'power-whey-choco',
+    name: 'Power Whey Choco',
+    brand: 'PureForce',
+    type: 'whey',
+    price: 54.9,
+    sizeGrams: 2000,
+    proteinPerServing: 24,
+    servings: 66,
+    flavor: 'Chocolat',
+    rating: 4.8,
+    link: '#',
+  },
+  {
+    id: 'grass-fed-strawberry',
+    name: 'Grass-Fed Strawberry',
+    brand: 'Alpine Nutrition',
+    type: 'whey',
+    price: 44.5,
+    sizeGrams: 1500,
+    proteinPerServing: 25,
+    servings: 50,
+    flavor: 'Fraise',
+    rating: 4.7,
+    link: '#',
+  },
+  {
+    id: 'creapure-performance',
+    name: 'Creapure Performance',
+    brand: 'PureForce',
+    type: 'creatine',
+    price: 24.9,
+    sizeGrams: 500,
+    proteinPerServing: 0,
+    creatinePerServing: 5,
+    servings: 100,
+    flavor: 'Neutre',
+    rating: 4.9,
+    link: '#',
+  },
+  {
+    id: 'micronized-creatine',
+    name: 'Micronized Creatine',
+    brand: 'NutriFuel',
+    type: 'creatine',
+    price: 18.5,
+    sizeGrams: 300,
+    proteinPerServing: 0,
+    creatinePerServing: 5,
+    servings: 60,
+    flavor: 'Neutre',
+    rating: 4.5,
+    link: '#',
+  },
+  {
+    id: 'vegan-whey-mix',
+    name: 'Vegan Whey Mix',
+    brand: 'GreenLab',
+    type: 'whey',
+    price: 32.0,
+    sizeGrams: 1000,
+    proteinPerServing: 23,
+    servings: 33,
+    flavor: 'Cookies',
+    rating: 4.2,
+    link: '#',
+  },
+];

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type { Product } from '../data/products';
+import { products } from '../data/products';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const useProducts = () =>
+  useQuery<Product[]>({
+    queryKey: ['products'],
+    queryFn: async () => {
+      await wait(400);
+      return products;
+    },
+    staleTime: 1000 * 60 * 5,
+  });

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import App from './App';
+import './index.css';
+
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/src/store/productSelectionStore.ts
+++ b/src/store/productSelectionStore.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand';
+
+import type { ProductType } from '../data/products';
+
+type Range = [number, number];
+
+interface ProductSelectionState {
+  selectedBrands: string[];
+  selectedTypes: ProductType[];
+  priceBounds: Range;
+  priceRange: Range;
+  selectedProductIds: string[];
+  setSelectedBrands: (brands: string[]) => void;
+  setSelectedTypes: (types: ProductType[]) => void;
+  setPriceBounds: (bounds: Range) => void;
+  setPriceRange: (range: Range) => void;
+  toggleProductSelection: (productId: string) => void;
+  clearSelection: () => void;
+}
+
+const defaultRange: Range = [0, 200];
+
+export const useProductSelectionStore = create<ProductSelectionState>((set) => ({
+  selectedBrands: [],
+  selectedTypes: [],
+  priceBounds: defaultRange,
+  priceRange: defaultRange,
+  selectedProductIds: [],
+  setSelectedBrands: (brands) => set({ selectedBrands: brands }),
+  setSelectedTypes: (types) => set({ selectedTypes: types }),
+  setPriceBounds: (bounds) =>
+    set({
+      priceBounds: bounds,
+      priceRange: bounds,
+    }),
+  setPriceRange: (range) => set({ priceRange: range }),
+  toggleProductSelection: (productId) =>
+    set((state) => {
+      if (state.selectedProductIds.includes(productId)) {
+        return {
+          selectedProductIds: state.selectedProductIds.filter((id) => id !== productId),
+        };
+      }
+
+      if (state.selectedProductIds.length >= 4) {
+        return state;
+      }
+
+      return {
+        selectedProductIds: [...state.selectedProductIds, productId],
+      };
+    }),
+  clearSelection: () => set({ selectedProductIds: [] }),
+}));
+
+export const selectFilters = (state: ProductSelectionState) => ({
+  selectedBrands: state.selectedBrands,
+  selectedTypes: state.selectedTypes,
+  priceBounds: state.priceBounds,
+  priceRange: state.priceRange,
+});
+
+export const selectSelectedProductIds = (state: ProductSelectionState) =>
+  state.selectedProductIds;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#f5f3ff',
+          100: '#ede9fe',
+          200: '#ddd6fe',
+          300: '#c4b5fd',
+          400: '#a78bfa',
+          500: '#8b5cf6',
+          600: '#7c3aed',
+          700: '#6d28d9',
+          800: '#5b21b6',
+          900: '#4c1d95',
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node"],
+    "module": "ESNext"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript project with TailwindCSS tooling
- add product dataset, React Query hook, and Zustand store to drive comparison state
- implement filter sidebar, KPI summary bar, and comparison table with skeleton loaders

## Testing
- not run (npm dependencies unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd53588fd88325a8ff9f0f3582ab59