### PR TITLE
feat: add hero, deals, and price alert sections to landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
 import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
-import { ProductFiltersSidebar } from './components/ProductFiltersSidebar';
+import { DealsShowcase } from './components/DealsShowcase';
+import { HeroSection } from './components/HeroSection';
 import { KpiSummaryBar } from './components/KpiSummaryBar';
+import { PriceAlertsSection } from './components/PriceAlertsSection';
 import { ProductComparisonTable } from './components/ProductComparisonTable';
+import { ProductFiltersSidebar } from './components/ProductFiltersSidebar';
 import { useProducts } from './hooks/useProducts';
 import { selectFilters, selectSelectedProductIds, useProductSelectionStore } from './store/productSelectionStore';
 
@@ -30,29 +33,39 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100">
-      <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 pb-12 pt-10 lg:px-8">
-        <header className="space-y-3">
-          <span className="inline-flex items-center rounded-full bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700">
-            Comparateur intelligent
-          </span>
-          <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">Comparez vos compléments favoris</h1>
-          <p className="max-w-2xl text-base text-slate-600">
-            Filtrez par marque, type et budget pour construire un comparatif entre deux et quatre produits.
-            Analysez les KPIs clés comme le prix par 100 g de protéine pour trouver le meilleur rapport
-            qualité/prix.
-          </p>
-        </header>
+      <div className="mx-auto flex max-w-7xl flex-col gap-12 px-4 pb-16 pt-12 lg:px-8 lg:pb-20 lg:pt-16">
+        <main className="flex flex-col gap-12 lg:gap-16">
+          <HeroSection />
 
-        <KpiSummaryBar selectedProducts={selectedProducts} isLoading={isLoading} />
+          <DealsShowcase />
 
-        <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
-          <ProductFiltersSidebar
-            allProducts={products}
-            filteredProducts={filteredProducts}
-            isLoading={isLoading}
-          />
-          <ProductComparisonTable products={selectedProducts} isLoading={isLoading} />
-        </div>
+          <PriceAlertsSection />
+
+          <section id="comparateur" className="space-y-8 rounded-3xl bg-white/70 p-6 shadow-lg shadow-slate-900/5 lg:p-8">
+            <header className="space-y-3">
+              <span className="inline-flex items-center rounded-full bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700">
+                Comparateur intelligent
+              </span>
+              <h2 className="text-3xl font-bold text-slate-900 sm:text-4xl">Comparez vos compléments favoris</h2>
+              <p className="max-w-2xl text-base text-slate-600">
+                Filtrez par marque, type et budget pour construire un comparatif entre deux et quatre produits.
+                Analysez les KPIs clés comme le prix par 100 g de protéine pour trouver le meilleur rapport
+                qualité/prix.
+              </p>
+            </header>
+
+            <KpiSummaryBar selectedProducts={selectedProducts} isLoading={isLoading} />
+
+            <div className="grid gap-6 lg:grid-cols-[320px,1fr] lg:gap-8">
+              <ProductFiltersSidebar
+                allProducts={products}
+                filteredProducts={filteredProducts}
+                isLoading={isLoading}
+              />
+              <ProductComparisonTable products={selectedProducts} isLoading={isLoading} />
+            </div>
+          </section>
+        </main>
       </div>
     </div>
   );

--- a/src/components/DealsShowcase.tsx
+++ b/src/components/DealsShowcase.tsx
@@ -1,0 +1,82 @@
+const deals = [
+  {
+    title: 'Pack performance 2kg',
+    discount: '-18%',
+    description: 'Idéal pour optimiser vos entraînements avec un prix au kilo imbattable cette semaine.',
+    badge: 'Offre flash',
+  },
+  {
+    title: 'Whey bio sans lactose',
+    discount: '-12%',
+    description: 'La whey la plus clean du moment, certifiée bio et livrée en 24h avec remise exclusive.',
+    badge: 'Sélection green',
+  },
+  {
+    title: 'Isolate premium 90%',
+    discount: '-25%',
+    description: 'Isolate haute pureté pour des résultats rapides, comparé automatiquement aux meilleurs prix.',
+    badge: 'Deal idealo',
+  },
+];
+
+export function DealsShowcase() {
+  return (
+    <section className="rounded-3xl bg-white p-8 shadow-lg shadow-slate-900/5">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="max-w-lg space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-600">Offres à ne pas manquer</p>
+          <h2 className="text-3xl font-bold text-slate-900">Promotions inspirées des meilleures sélections idealo</h2>
+          <p className="text-base text-slate-600">
+            Comparez les tarifs et les avantages de chaque offre avant de passer commande. Notre algorithme
+            met en avant les deals avec le meilleur prix par 100 g et la disponibilité la plus fiable.
+          </p>
+        </div>
+        <a
+          href="#comparateur"
+          className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+        >
+          Voir tous les produits comparés
+        </a>
+      </div>
+
+      <div className="mt-10 grid gap-6 md:grid-cols-3">
+        {deals.map((deal) => (
+          <article
+            key={deal.title}
+            className="group relative flex flex-col gap-4 rounded-2xl border border-slate-100 bg-slate-50/60 p-6 transition hover:border-primary-200 hover:bg-white"
+          >
+            <span className="inline-flex w-fit rounded-full bg-primary-100 px-3 py-1 text-xs font-semibold text-primary-700">
+              {deal.badge}
+            </span>
+            <h3 className="text-xl font-semibold text-slate-900">{deal.title}</h3>
+            <p className="text-sm text-slate-600">{deal.description}</p>
+            <div className="mt-auto flex items-center justify-between">
+              <span className="text-2xl font-bold text-primary-600">{deal.discount}</span>
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 text-sm font-semibold text-slate-900 transition group-hover:text-primary-600"
+              >
+                Découvrir l'offre
+                <svg
+                  className="h-4 w-4"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden
+                >
+                  <path
+                    d="M5 10h10m0 0l-4-4m4 4l-4 4"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,72 @@
+export function HeroSection() {
+  return (
+    <section className="relative overflow-hidden rounded-3xl bg-slate-900 px-8 py-16 text-white shadow-xl">
+      <div className="absolute -left-16 -top-16 h-64 w-64 rounded-full bg-primary-500/20 blur-3xl" aria-hidden />
+      <div className="absolute -right-24 bottom-0 h-80 w-80 rounded-full bg-primary-400/10 blur-3xl" aria-hidden />
+
+      <div className="relative z-10 flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+        <div className="max-w-xl space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-sm font-medium">
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden
+            >
+              <path
+                d="M12 3l1.65 4.95L18 9.6l-4.35 1.65L12 16.2l-1.65-4.95L6 9.6l4.35-1.65L12 3z"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Comparateur nouvelle génération
+          </span>
+          <div className="space-y-4">
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+              Comparez les meilleures whey en un clin d'oeil
+            </h1>
+            <p className="text-lg text-slate-200">
+              Visualisez instantanément le rapport qualité/prix de vos compléments favoris, avec des
+              indicateurs clés et des conseils personnalisés inspirés de l'expérience idealo.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <a
+              href="#comparateur"
+              className="inline-flex items-center justify-center rounded-full bg-primary-400 px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-primary-900/20 transition hover:bg-primary-300"
+            >
+              Lancer le comparatif
+            </a>
+            <a
+              href="#alertes-prix"
+              className="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10"
+            >
+              Activer une alerte personnalisée
+            </a>
+          </div>
+        </div>
+        <div className="w-full max-w-md rounded-3xl bg-white/5 p-6 backdrop-blur">
+          <div className="space-y-4">
+            <p className="text-sm uppercase tracking-[0.2em] text-primary-200">Pourquoi comparer ?</p>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2.5 w-2.5 rounded-full bg-primary-300" aria-hidden />
+                Identifiez les meilleures offres selon votre budget et votre apport protéique.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2.5 w-2.5 rounded-full bg-primary-300" aria-hidden />
+                Surveillez les promotions flash pour acheter au moment idéal.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2.5 w-2.5 rounded-full bg-primary-300" aria-hidden />
+                Configurez des alertes prix pour être prévenu dès que votre cible est atteinte.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/PriceAlertsSection.tsx
+++ b/src/components/PriceAlertsSection.tsx
@@ -1,0 +1,56 @@
+export function PriceAlertsSection() {
+  return (
+    <section
+      id="alertes-prix"
+      className="relative overflow-hidden rounded-3xl border border-primary-100 bg-primary-50/60 p-8"
+    >
+      <div className="absolute -right-10 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-primary-200/40 blur-3xl" aria-hidden />
+      <div className="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="max-w-xl space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-600">Alertes prix</p>
+          <h2 className="text-3xl font-bold text-slate-900">Soyez averti dès qu'une whey atteint votre prix cible</h2>
+          <p className="text-base text-slate-600">
+            Configurez une alerte et recevez un email lorsqu'une boutique partenaire passe sous votre prix
+            idéal. Inspiré du suivi intelligent idealo, vous ne raterez plus jamais un bon plan.
+          </p>
+        </div>
+        <form className="w-full max-w-md space-y-4 rounded-2xl bg-white p-6 shadow-sm shadow-primary-900/10">
+          <div className="space-y-1">
+            <label htmlFor="alert-email" className="text-sm font-medium text-slate-700">
+              Adresse email
+            </label>
+            <input
+              id="alert-email"
+              type="email"
+              placeholder="vous@exemple.com"
+              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm transition focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="alert-target" className="text-sm font-medium text-slate-700">
+              Prix cible (€/kg)
+            </label>
+            <input
+              id="alert-target"
+              type="number"
+              min="0"
+              step="0.5"
+              placeholder="Ex : 18"
+              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm transition focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            />
+          </div>
+          <button
+            type="button"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-primary-400"
+          >
+            Créer mon alerte personnalisée
+          </button>
+          <p className="text-xs text-slate-500">
+            Nous surveillons en continu les variations de prix. Recevez un résumé complet avant que l'offre ne
+            disparaisse.
+          </p>
+        </form>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- create dedicated hero, deals, and price alert components with idealo-inspired CTAs
- reorganize the main app layout to integrate the new sections before the existing comparison tools

## Testing
- npm run build *(fails: TS2688 Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68de3d5669748325b27d7d498b2145f9