### PR TITLE
Add price alert subscription workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,19 @@
 import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
-import { ProductFiltersSidebar } from './components/ProductFiltersSidebar';
 import { KpiSummaryBar } from './components/KpiSummaryBar';
+import { PriceAlertForm } from './components/PriceAlertForm';
+import { ProductFiltersSidebar } from './components/ProductFiltersSidebar';
 import { ProductComparisonTable } from './components/ProductComparisonTable';
 import { useProducts } from './hooks/useProducts';
 import { selectFilters, selectSelectedProductIds, useProductSelectionStore } from './store/productSelectionStore';
+import { usePriceAlertStore } from './store/priceAlertStore';
 
 export default function App() {
   const { data: products = [], isLoading } = useProducts();
   const filters = useProductSelectionStore(useShallow(selectFilters));
   const selectedProductIds = useProductSelectionStore(selectSelectedProductIds);
+  const activeAlertCount = usePriceAlertStore((state) => state.alerts.length);
 
   const filteredProducts = useMemo(() => {
     return products.filter((product) => {
@@ -41,6 +44,21 @@ export default function App() {
             Analysez les KPIs clés comme le prix par 100 g de protéine pour trouver le meilleur rapport
             qualité/prix.
           </p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <a
+              href="#price-alerts"
+              className="inline-flex items-center justify-center rounded-full bg-primary-600 px-5 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary-500"
+            >
+              Activer une alerte prix
+            </a>
+            <span className="text-sm text-slate-500">
+              {activeAlertCount > 0
+                ? `${activeAlertCount} alerte${activeAlertCount > 1 ? 's' : ''} active${
+                    activeAlertCount > 1 ? 's' : ''
+                  }`
+                : 'Recevez un e-mail dès qu’un prix baisse.'}
+            </span>
+          </div>
         </header>
 
         <KpiSummaryBar selectedProducts={selectedProducts} isLoading={isLoading} />
@@ -53,6 +71,20 @@ export default function App() {
           />
           <ProductComparisonTable products={selectedProducts} isLoading={isLoading} />
         </div>
+
+        <section
+          id="price-alerts"
+          className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm md:p-8"
+        >
+          <div className="space-y-2 pb-4">
+            <h2 className="text-2xl font-semibold text-slate-900">Alertes prix personnalisées</h2>
+            <p className="text-sm text-slate-600">
+              Suivez l’évolution du prix de vos compléments préférés et recevez une notification dès qu’ils
+              passent sous votre seuil.
+            </p>
+          </div>
+          <PriceAlertForm products={products} />
+        </section>
       </div>
     </div>
   );

--- a/src/components/PriceAlertForm.tsx
+++ b/src/components/PriceAlertForm.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+
+import type { Product } from '../data/products';
+import { usePriceAlertStore } from '../store/priceAlertStore';
+
+interface PriceAlertFormProps {
+  products: Product[];
+}
+
+interface FormErrors {
+  email?: string;
+  productId?: string;
+  priceThreshold?: string;
+}
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function PriceAlertForm({ products }: PriceAlertFormProps) {
+  const { email, productId, priceThreshold, alerts, status, message } = usePriceAlertStore(
+    useShallow((state) => ({
+      email: state.email,
+      productId: state.productId,
+      priceThreshold: state.priceThreshold,
+      alerts: state.alerts,
+      status: state.status,
+      message: state.message,
+    })),
+  );
+
+  const { setEmail, setProductId, setPriceThreshold, subscribeToAlert, removeAlert, clearStatus } =
+    usePriceAlertStore(
+      useShallow((state) => ({
+        setEmail: state.setEmail,
+        setProductId: state.setProductId,
+        setPriceThreshold: state.setPriceThreshold,
+        subscribeToAlert: state.subscribeToAlert,
+        removeAlert: state.removeAlert,
+        clearStatus: state.clearStatus,
+      })),
+    );
+
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  useEffect(() => {
+    if (status === 'success' || status === 'error') {
+      const timeout = window.setTimeout(() => {
+        clearStatus();
+      }, 5000);
+
+      return () => window.clearTimeout(timeout);
+    }
+
+    return undefined;
+  }, [status, clearStatus]);
+
+  const productOptions = useMemo(
+    () =>
+      products.map((product) => ({
+        id: product.id,
+        label: `${product.name} — ${product.brand}`,
+      })),
+    [products],
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (status === 'loading') {
+      return;
+    }
+
+    const newErrors: FormErrors = {};
+
+    if (!email) {
+      newErrors.email = 'Veuillez saisir votre e-mail.';
+    } else if (!emailPattern.test(email)) {
+      newErrors.email = 'Adresse e-mail invalide.';
+    }
+
+    if (!productId) {
+      newErrors.productId = 'Sélectionnez un produit.';
+    }
+
+    const numericThreshold = Number(priceThreshold);
+    if (!priceThreshold) {
+      newErrors.priceThreshold = 'Indiquez un seuil de prix.';
+    } else if (Number.isNaN(numericThreshold) || numericThreshold <= 0) {
+      newErrors.priceThreshold = 'Le seuil doit être supérieur à 0 €.';
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    const product = products.find((item) => item.id === productId);
+    if (!product) {
+      setErrors({ productId: 'Produit introuvable.' });
+      return;
+    }
+
+    setErrors({});
+    await subscribeToAlert({ id: product.id, name: product.name }, numericThreshold);
+  };
+
+  const hasAlerts = alerts.length > 0;
+  const isLoading = status === 'loading';
+
+  return (
+    <div className="space-y-8">
+      <form className="grid gap-4 md:grid-cols-3" onSubmit={handleSubmit}>
+        <div className="md:col-span-1">
+          <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="price-alert-email">
+            Adresse e-mail
+          </label>
+          <input
+            id="price-alert-email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            placeholder="vous@exemple.com"
+          />
+          {errors.email ? <p className="mt-1 text-xs text-red-600">{errors.email}</p> : null}
+        </div>
+
+        <div className="md:col-span-1">
+          <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="price-alert-product">
+            Produit à surveiller
+          </label>
+          <select
+            id="price-alert-product"
+            value={productId}
+            onChange={(event) => setProductId(event.target.value)}
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+          >
+            <option value="">Sélectionnez un produit</option>
+            {productOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {errors.productId ? <p className="mt-1 text-xs text-red-600">{errors.productId}</p> : null}
+        </div>
+
+        <div className="md:col-span-1">
+          <label
+            className="mb-1 block text-sm font-medium text-slate-700"
+            htmlFor="price-alert-threshold"
+          >
+            Seuil de prix (€)
+          </label>
+          <input
+            id="price-alert-threshold"
+            type="number"
+            min={1}
+            step="0.5"
+            inputMode="decimal"
+            value={priceThreshold}
+            onChange={(event) => setPriceThreshold(event.target.value)}
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            placeholder="ex. 29.90"
+          />
+          {errors.priceThreshold ? (
+            <p className="mt-1 text-xs text-red-600">{errors.priceThreshold}</p>
+          ) : null}
+        </div>
+
+        <div className="md:col-span-3 flex flex-wrap items-center justify-end gap-3">
+          <button
+            type="submit"
+            disabled={isLoading || products.length === 0}
+            className="inline-flex items-center justify-center rounded-full bg-primary-600 px-5 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {isLoading ? 'Enregistrement…' : 'Créer une alerte'}
+          </button>
+          {products.length === 0 ? (
+            <span className="text-xs text-slate-500">Aucun produit disponible pour le moment.</span>
+          ) : null}
+        </div>
+      </form>
+
+      {status !== 'idle' && message ? (
+        <div
+          className={`rounded-2xl border px-4 py-3 text-sm shadow-sm md:px-6 ${
+            status === 'success'
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+              : 'border-red-200 bg-red-50 text-red-700'
+          }`}
+        >
+          {message}
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+            Alertes actives
+          </h3>
+          {hasAlerts ? (
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+              {alerts.length} active{alerts.length > 1 ? 's' : ''}
+            </span>
+          ) : null}
+        </div>
+
+        {hasAlerts ? (
+          <ul className="divide-y divide-slate-200 rounded-2xl border border-slate-200 bg-white shadow-sm">
+            {alerts.map((alert) => (
+              <li key={alert.id} className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                <div>
+                  <p className="text-sm font-medium text-slate-800">{alert.productName}</p>
+                  <p className="text-xs text-slate-500">
+                    {alert.email} — seuil : {alert.priceThreshold.toFixed(2)} €
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeAlert(alert.id)}
+                  className="inline-flex items-center justify-center rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 transition hover:border-red-300 hover:text-red-600"
+                >
+                  Désactiver
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-slate-500">
+            Configurez une alerte pour être averti dès qu’un produit passe sous votre prix cible.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SERPAI_PRICE_ALERT_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/store/priceAlertStore.ts
+++ b/src/store/priceAlertStore.ts
@@ -1,0 +1,119 @@
+import { create } from 'zustand';
+
+interface ProductSummary {
+  id: string;
+  name: string;
+}
+
+type SubscriptionStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface PriceAlertSubscription {
+  id: string;
+  email: string;
+  productId: string;
+  productName: string;
+  priceThreshold: number;
+  createdAt: string;
+}
+
+interface PriceAlertState {
+  email: string;
+  productId: string;
+  priceThreshold: string;
+  alerts: PriceAlertSubscription[];
+  status: SubscriptionStatus;
+  message?: string;
+  setEmail: (email: string) => void;
+  setProductId: (productId: string) => void;
+  setPriceThreshold: (value: string) => void;
+  clearStatus: () => void;
+  resetForm: () => void;
+  removeAlert: (alertId: string) => void;
+  subscribeToAlert: (product: ProductSummary, thresholdValue: number) => Promise<boolean>;
+}
+
+const createSubscription = (
+  email: string,
+  product: ProductSummary,
+  priceThreshold: number,
+): PriceAlertSubscription => ({
+  id: `${product.id}-${Date.now()}`,
+  email,
+  productId: product.id,
+  productName: product.name,
+  priceThreshold,
+  createdAt: new Date().toISOString(),
+});
+
+export const usePriceAlertStore = create<PriceAlertState>((set, get) => ({
+  email: '',
+  productId: '',
+  priceThreshold: '',
+  alerts: [],
+  status: 'idle',
+  message: undefined,
+  setEmail: (email) => set({ email }),
+  setProductId: (productId) => set({ productId }),
+  setPriceThreshold: (value) => set({ priceThreshold: value }),
+  clearStatus: () => set({ status: 'idle', message: undefined }),
+  resetForm: () => set({ productId: '', priceThreshold: '' }),
+  removeAlert: (alertId) =>
+    set((state) => ({ alerts: state.alerts.filter((alert) => alert.id !== alertId) })),
+  subscribeToAlert: async (product, thresholdValue) => {
+    const { email } = get();
+    set({ status: 'loading', message: undefined });
+
+    const serapiEndpoint = import.meta.env.VITE_SERPAI_PRICE_ALERT_URL;
+
+    try {
+      if (serapiEndpoint) {
+        const response = await fetch(serapiEndpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            email,
+            productId: product.id,
+            priceThreshold: thresholdValue,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error('SerpAI subscription failed');
+        }
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+        const shouldFail = Math.random() < 0.15;
+        if (shouldFail) {
+          throw new Error('Simulated failure');
+        }
+      }
+
+      const newAlert = createSubscription(email, product, thresholdValue);
+
+      set((state) => ({
+        alerts: [
+          ...state.alerts.filter(
+            (existing) => !(existing.email === email && existing.productId === product.id),
+          ),
+          newAlert,
+        ],
+        status: 'success',
+        message: `Vous serez averti si ${product.name} passe sous ${thresholdValue.toFixed(2)} €.`,
+        productId: '',
+        priceThreshold: '',
+      }));
+
+      return true;
+    } catch (error) {
+      const fallbackMessage =
+        error instanceof Error && error.message === 'SerpAI subscription failed'
+          ? "Le service d'alertes est temporairement indisponible."
+          : "Nous n'avons pas pu enregistrer votre alerte. Merci de réessayer.";
+
+      set({ status: 'error', message: fallbackMessage });
+      return false;
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- add a dedicated Zustand store to capture price alert form fields, simulated/SerpAI submission status, and active subscriptions
- create a reusable PriceAlertForm component with basic validation, success/error messaging, and alert management controls
- surface the price alert CTA and section in App.tsx and document the optional SerpAI endpoint in the Vite env types

## Testing
- npm run build *(fails: missing `@types/node` typings and restricted registry prevents installing them)*

------
https://chatgpt.com/codex/tasks/task_e_68de3d5ad47483259fd7bdf96374cae8