### PR TITLE
Refactor landing page into modular sections

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,74 +1,75 @@
 "use client";
 
+import { useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { motion } from "framer-motion";
 
-interface Categorie {
-  titre: string;
-  query: string;
-  icon: string;
-  bg: string;
-}
+import { HeroSection } from "@/components/HeroSection";
+import { DealsShowcase } from "@/components/DealsShowcase";
+import { ComparatorSummary, Category } from "@/components/ComparatorSummary";
+import { PriceAlertsSection } from "@/components/PriceAlertsSection";
 
-const categories: Categorie[] = [
+const categories: Category[] = [
   { titre: "Whey Protein", query: "whey protein", icon: "💪", bg: "bg-orange-500" },
   { titre: "Créatine", query: "creatine", icon: "⚡", bg: "bg-blue-600" },
   { titre: "BCAA", query: "bcaa", icon: "🍃", bg: "bg-green-500" },
   { titre: "Pré-Workout", query: "pre workout", icon: "🔥", bg: "bg-red-500" },
   { titre: "Accessoires Gym", query: "accessoires musculation fitness", icon: "🏋️‍♂️", bg: "bg-purple-500" },
   { titre: "Vêtements Sportifs", query: "vêtements sport running fitness homme femme", icon: "👕", bg: "bg-teal-500" },
-  { titre: "Catalogue", query: "__catalogue__", icon: "📘", bg: "bg-gray-700" }, // Nouvelle tuile
+  { titre: "Catalogue", query: "__catalogue__", icon: "📘", bg: "bg-gray-700" },
 ];
 
 export default function Home() {
   const router = useRouter();
 
-  const handleClick = (query: string) => {
-    if (query === "__catalogue__") {
-      router.push("/catalogue"); // redirection vers la nouvelle page catalogue
-    } else {
-      router.push(`/comparateur?q=${encodeURIComponent(query)}`);
-    }
-  };
+  const handleStartComparison = useCallback(() => {
+    router.push("/comparateur");
+  }, [router]);
+
+  const handleViewDeals = useCallback(() => {
+    document.getElementById("promotions")?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  const handleExploreCatalogue = useCallback(() => {
+    router.push("/catalogue");
+  }, [router]);
+
+  const handleSelectCategory = useCallback(
+    (query: string) => {
+      if (query === "__catalogue__") {
+        router.push("/catalogue");
+      } else {
+        router.push(`/comparateur?q=${encodeURIComponent(query)}`);
+      }
+    },
+    [router]
+  );
 
   return (
-    <div className="min-h-screen bg-gradient-to-r from-[#0d1b2a] to-[#1b263b] text-white font-sans flex flex-col">
-      {/* Header */}
-      <header className="bg-[#0d1b2a] py-6 shadow-lg">
-        <div className="container mx-auto px-6 flex justify-between items-center">
+    <div className="min-h-screen bg-[#0b1320] text-white">
+      <header className="border-b border-white/10 bg-[#0d1b2a]/80 backdrop-blur">
+        <div className="container mx-auto flex items-center justify-between px-6 py-6">
           <h1 className="text-2xl font-extrabold text-orange-500">💪 Sport Comparator</h1>
-          <p className="text-gray-300">Comparez les meilleurs suppléments & équipements</p>
+          <nav className="hidden sm:flex items-center gap-6 text-sm text-gray-300">
+            <button onClick={handleStartComparison} className="transition hover:text-white">
+              Comparateur
+            </button>
+            <button onClick={handleViewDeals} className="transition hover:text-white">
+              Promotions
+            </button>
+            <button onClick={handleExploreCatalogue} className="transition hover:text-white">
+              Catalogue
+            </button>
+          </nav>
         </div>
       </header>
 
-      {/* Hero */}
-      <section className="text-center py-16">
-        <h2 className="text-4xl font-bold mb-4">Trouvez le meilleur prix 💰</h2>
-        <p className="text-lg text-gray-300">
-          Suppléments, accessoires et vêtements sportifs au meilleur prix
-        </p>
-      </section>
-
-      {/* Catégories */}
-      <main className="container mx-auto px-6 py-12 flex-1">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {categories.map((cat, i) => (
-            <motion.div
-              key={cat.titre}
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: i * 0.05 }}
-              onClick={() => handleClick(cat.query)}
-              className={`cursor-pointer p-6 rounded-xl shadow-lg hover:shadow-2xl transition ${cat.bg} flex flex-col items-center justify-center`}
-            >
-              <span className="text-5xl">{cat.icon}</span>
-              <h3 className="text-xl font-bold mt-4">{cat.titre}</h3>
-            </motion.div>
-          ))}
-        </div>
+      <main>
+        <HeroSection onStartComparison={handleStartComparison} onViewDeals={handleViewDeals} />
+        <DealsShowcase />
+        <ComparatorSummary categories={categories} onSelectCategory={handleSelectCategory} />
+        <PriceAlertsSection onExploreCatalogue={handleExploreCatalogue} />
       </main>
 
-      {/* Footer */}
       <footer className="bg-[#0d1b2a] py-6 text-center text-sm text-gray-400">
         © {new Date().getFullYear()} Sport Comparator — Inspiré par Idealo & LeDénicheur
       </footer>

--- a/frontend/src/components/ComparatorSummary.tsx
+++ b/frontend/src/components/ComparatorSummary.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export interface Category {
+  titre: string;
+  query: string;
+  icon: string;
+  bg: string;
+}
+
+interface ComparatorSummaryProps {
+  categories: Category[];
+  onSelectCategory: (query: string) => void;
+}
+
+export function ComparatorSummary({ categories, onSelectCategory }: ComparatorSummaryProps) {
+  return (
+    <section className="bg-[#0d1b2a] py-20">
+      <div className="container mx-auto px-6">
+        <div className="grid lg:grid-cols-[1.2fr_1fr] gap-12 items-start">
+          <motion.div
+            initial={{ opacity: 0, x: -30 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true, amount: 0.3 }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold text-white">Pourquoi utiliser notre comparateur ?</h2>
+            <p className="mt-4 text-gray-300">
+              Accédez à des centaines de produits sélectionnés parmi les leaders du marché du sport
+              et laissez notre algorithme trouver en quelques secondes le prix le plus bas.
+            </p>
+            <ul className="mt-8 space-y-4 text-gray-200">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 text-orange-400">★</span>
+                <span>Analyse multi-boutiques et suivi en temps réel des fluctuations tarifaires.</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 text-orange-400">★</span>
+                <span>Filtres poussés pour comparer les saveurs, formats et compositions.</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 text-orange-400">★</span>
+                <span>Alertes prix personnalisables sur vos marques favorites.</span>
+              </li>
+            </ul>
+          </motion.div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {categories.map((category, index) => (
+              <motion.button
+                key={category.titre}
+                onClick={() => onSelectCategory(category.query)}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ delay: index * 0.05 }}
+                className={`flex flex-col items-start rounded-2xl px-5 py-6 text-left text-white shadow-lg transition transform hover:-translate-y-1 hover:shadow-2xl ${category.bg}`}
+              >
+                <span className="text-3xl">{category.icon}</span>
+                <span className="mt-3 text-lg font-semibold">{category.titre}</span>
+                <span className="mt-2 text-sm text-white/80">Comparer &gt;</span>
+              </motion.button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/DealsShowcase.tsx
+++ b/frontend/src/components/DealsShowcase.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const deals = [
+  {
+    title: "Whey Isolate 2kg",
+    description: "-35% sur la marque OptiPower + livraison offerte",
+    badge: "Top Deal",
+    color: "from-orange-500/80 to-red-500/80",
+  },
+  {
+    title: "Créatine monohydrate",
+    description: "Pot 500g à 14,90€ — stock limité",
+    badge: "Flash",
+    color: "from-blue-500/80 to-cyan-500/80",
+  },
+  {
+    title: "Ceinture de force",
+    description: "Accessoire premium cuir -20% jusqu'à dimanche",
+    badge: "Accessoires",
+    color: "from-purple-500/80 to-pink-500/80",
+  },
+];
+
+export function DealsShowcase() {
+  return (
+    <section id="promotions" className="bg-[#0b1320] py-20">
+      <div className="container mx-auto px-6">
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-6 mb-12">
+          <div>
+            <h2 className="text-3xl sm:text-4xl font-bold text-white">Promos à ne pas manquer</h2>
+            <p className="mt-3 text-gray-300">
+              Des offres négociées avec les meilleurs e-shops spécialisés fitness.
+            </p>
+          </div>
+          <p className="text-sm text-gray-400">Actualisées plusieurs fois par jour</p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {deals.map((deal, index) => (
+            <motion.article
+              key={deal.title}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ delay: index * 0.1 }}
+              className={`relative overflow-hidden rounded-2xl bg-gradient-to-br ${deal.color} p-6 shadow-lg`}
+            >
+              <span className="inline-flex items-center px-3 py-1 text-xs font-semibold uppercase tracking-wider bg-black/30 rounded-full mb-4">
+                {deal.badge}
+              </span>
+              <h3 className="text-2xl font-semibold text-white">{deal.title}</h3>
+              <p className="mt-3 text-sm text-white/90">{deal.description}</p>
+              <motion.button
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.97 }}
+                className="mt-8 inline-flex items-center gap-2 rounded-full bg-black/30 px-4 py-2 text-sm font-medium text-white"
+              >
+                Profiter de l'offre →
+              </motion.button>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/HeroSection.tsx
+++ b/frontend/src/components/HeroSection.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface HeroSectionProps {
+  onStartComparison: () => void;
+  onViewDeals: () => void;
+}
+
+export function HeroSection({ onStartComparison, onViewDeals }: HeroSectionProps) {
+  return (
+    <section className="relative overflow-hidden py-24 bg-gradient-to-br from-[#0d1b2a] via-[#1b263b] to-[#415a77] text-white">
+      <div className="container mx-auto px-6">
+        <motion.div
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="max-w-3xl"
+        >
+          <p className="uppercase tracking-[0.3em] text-sm text-orange-400 mb-4">Comparateur nouvelle génération</p>
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold leading-tight">
+            Ne payez plus jamais votre whey au prix fort
+          </h1>
+          <p className="mt-6 text-lg text-gray-200">
+            Sport Comparator agrège les meilleures boutiques en ligne pour vous proposer
+            des suppléments, équipements et tenues de sport au meilleur tarif, en temps réel.
+          </p>
+          <div className="mt-10 flex flex-col sm:flex-row gap-4">
+            <button
+              onClick={onStartComparison}
+              className="rounded-full bg-orange-500 hover:bg-orange-400 transition-colors px-8 py-3 font-semibold shadow-lg"
+            >
+              Lancer le comparateur
+            </button>
+            <button
+              onClick={onViewDeals}
+              className="rounded-full border border-white/40 hover:border-orange-300 hover:text-orange-200 transition-colors px-8 py-3 font-semibold"
+            >
+              Voir les promos
+            </button>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/PriceAlertsSection.tsx
+++ b/frontend/src/components/PriceAlertsSection.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface PriceAlertsSectionProps {
+  onExploreCatalogue: () => void;
+}
+
+export function PriceAlertsSection({ onExploreCatalogue }: PriceAlertsSectionProps) {
+  return (
+    <section className="bg-[#1b263b] py-20 text-white">
+      <div className="container mx-auto px-6">
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.3 }}
+            transition={{ duration: 0.5 }}
+            className="space-y-6"
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold">Ne ratez plus la bonne affaire</h2>
+            <p className="text-gray-200">
+              Activez des alertes pour être prévenu dès qu'un prix chute ou qu'un nouveau marchand
+              référence vos produits favoris. Personnalisez vos seuils par marque, catégorie ou format.
+            </p>
+            <ul className="space-y-3 text-gray-300">
+              <li className="flex items-center gap-3">
+                <span className="text-orange-400">✓</span>
+                Notifications e-mail hebdo ou instantanées
+              </li>
+              <li className="flex items-center gap-3">
+                <span className="text-orange-400">✓</span>
+                Historique des prix et tendances saisonnières
+              </li>
+              <li className="flex items-center gap-3">
+                <span className="text-orange-400">✓</span>
+                Suggestions intelligentes selon vos achats précédents
+              </li>
+            </ul>
+            <div className="pt-4">
+              <button
+                onClick={onExploreCatalogue}
+                className="inline-flex items-center gap-2 rounded-full bg-orange-500 px-6 py-3 font-semibold text-white transition-colors hover:bg-orange-400"
+              >
+                Découvrir le catalogue
+                <span aria-hidden>→</span>
+              </button>
+            </div>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            whileInView={{ opacity: 1, scale: 1 }}
+            viewport={{ once: true, amount: 0.3 }}
+            transition={{ duration: 0.5 }}
+            className="relative rounded-3xl bg-[#0d1b2a] p-8 shadow-2xl"
+          >
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm uppercase tracking-widest text-gray-400">Alerte active</span>
+                <span className="rounded-full bg-green-500/20 px-3 py-1 text-xs text-green-300">-12% détecté</span>
+              </div>
+              <div>
+                <h3 className="text-2xl font-semibold">Whey Native - Chocolat</h3>
+                <p className="text-gray-300">Prix cible : 22,90€ • Actuel : 21,50€</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p className="text-sm text-gray-300">
+                  "Notification envoyée à 8h12 — remise exceptionnelle chez FitShop."
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm text-gray-300">
+                <div className="rounded-xl bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-widest text-gray-400">Historique 30j</p>
+                  <p className="mt-1 text-lg font-semibold text-white">-18%</p>
+                </div>
+                <div className="rounded-xl bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-widest text-gray-400">Boutiques suivies</p>
+                  <p className="mt-1 text-lg font-semibold text-white">12</p>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- restructure the home page into hero, deals, comparator summary, and price alert sections
- add dedicated components to share framer-motion animations and CTA logic
- keep routing hooks for the comparator and catalogue with smooth scrolling to promotions

## Testing
- not run (environment does not have Next.js dependencies available)


------
https://chatgpt.com/codex/tasks/task_e_68de449f24c88325b0b577664f57e71b