### PR TITLE
feat: dynamiser les promos avec un catalogue typé

### DIFF
--- a/frontend/src/components/DealsShowcase.tsx
+++ b/frontend/src/components/DealsShowcase.tsx
@@ -1,64 +1,132 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 
-const deals = [
-  {
-    title: "Whey Isolate 2kg",
-    description: "-35% sur la marque OptiPower + livraison offerte",
-    badge: "Top Deal",
-    color: "from-orange-500/80 to-red-500/80",
-  },
-  {
-    title: "Créatine monohydrate",
-    description: "Pot 500g à 14,90€ — stock limité",
-    badge: "Flash",
-    color: "from-blue-500/80 to-cyan-500/80",
-  },
-  {
-    title: "Ceinture de force",
-    description: "Accessoire premium cuir -20% jusqu'à dimanche",
-    badge: "Accessoires",
-    color: "from-purple-500/80 to-pink-500/80",
-  },
-];
+import { deals, Deal } from "@/data/deals";
+
+const priceFormatter = new Intl.NumberFormat("fr-FR", {
+  style: "currency",
+  currency: "EUR",
+  minimumFractionDigits: 2,
+});
+
+const formatRemainingTime = (deadline: string) => {
+  const diff = new Date(deadline).getTime() - Date.now();
+
+  if (Number.isNaN(diff) || diff <= 0) {
+    return "Expirée";
+  }
+
+  const totalSeconds = Math.floor(diff / 1000);
+  const days = Math.floor(totalSeconds / (24 * 3600));
+  const hours = Math.floor((totalSeconds % (24 * 3600)) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 0) {
+    return `${days}j ${hours}h ${minutes}m`;
+  }
+
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+};
+
+function useDealCountdown(deadline?: string) {
+  const [remaining, setRemaining] = useState(() =>
+    deadline ? formatRemainingTime(deadline) : undefined
+  );
+
+  useEffect(() => {
+    if (!deadline) {
+      return;
+    }
+
+    const tick = () => {
+      setRemaining(formatRemainingTime(deadline));
+    };
+
+    tick();
+    const interval = window.setInterval(tick, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [deadline]);
+
+  return remaining;
+}
+
+function DealCard({ deal, index }: { deal: Deal; index: number }) {
+  const countdown = useDealCountdown(deal.deadline);
+  const discountBadge = useMemo(
+    () => `-${deal.discountPercent}%`,
+    [deal.discountPercent]
+  );
+
+  return (
+    <motion.article
+      key={deal.id}
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ delay: index * 0.1 }}
+      className={`relative overflow-hidden rounded-2xl bg-gradient-to-br ${deal.color} p-6 shadow-lg`}
+    >
+      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wider text-white/80">
+        <span className="inline-flex items-center gap-2 rounded-full bg-black/30 px-3 py-1">
+          {deal.badge}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-black/30 px-3 py-1">
+          {discountBadge}
+        </span>
+      </div>
+      <h3 className="mt-4 text-2xl font-semibold text-white">
+        {deal.productName}
+      </h3>
+      <p className="mt-3 text-sm text-white/90">{deal.hook}</p>
+      <div className="mt-6 flex items-end gap-3 text-white">
+        <span className="text-3xl font-bold">
+          {priceFormatter.format(deal.currentPrice)}
+        </span>
+        <span className="text-sm text-white/70 line-through">
+          {priceFormatter.format(deal.originalPrice)}
+        </span>
+      </div>
+      {countdown && (
+        <div className="mt-4 inline-flex items-center gap-2 rounded-full bg-black/30 px-3 py-1 text-xs font-medium text-white/80">
+          <span>⏱️ Offre</span>
+          <span>{countdown}</span>
+        </div>
+      )}
+      <motion.button
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.97 }}
+        className="mt-8 inline-flex items-center gap-2 rounded-full bg-black/30 px-4 py-2 text-sm font-medium text-white"
+      >
+        {deal.ctaLabel}
+      </motion.button>
+    </motion.article>
+  );
+}
 
 export function DealsShowcase() {
   return (
     <section id="promotions" className="bg-[#0b1320] py-20">
       <div className="container mx-auto px-6">
-        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-6 mb-12">
+        <div className="mb-12 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 className="text-3xl sm:text-4xl font-bold text-white">Promos à ne pas manquer</h2>
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">
+              Promos à ne pas manquer
+            </h2>
             <p className="mt-3 text-gray-300">
               Des offres négociées avec les meilleurs e-shops spécialisés fitness.
             </p>
           </div>
           <p className="text-sm text-gray-400">Actualisées plusieurs fois par jour</p>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
           {deals.map((deal, index) => (
-            <motion.article
-              key={deal.title}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ delay: index * 0.1 }}
-              className={`relative overflow-hidden rounded-2xl bg-gradient-to-br ${deal.color} p-6 shadow-lg`}
-            >
-              <span className="inline-flex items-center px-3 py-1 text-xs font-semibold uppercase tracking-wider bg-black/30 rounded-full mb-4">
-                {deal.badge}
-              </span>
-              <h3 className="text-2xl font-semibold text-white">{deal.title}</h3>
-              <p className="mt-3 text-sm text-white/90">{deal.description}</p>
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.97 }}
-                className="mt-8 inline-flex items-center gap-2 rounded-full bg-black/30 px-4 py-2 text-sm font-medium text-white"
-              >
-                Profiter de l'offre →
-              </motion.button>
-            </motion.article>
+            <DealCard key={deal.id} deal={deal} index={index} />
           ))}
         </div>
       </div>

--- a/frontend/src/data/deals.ts
+++ b/frontend/src/data/deals.ts
@@ -1,0 +1,61 @@
+export interface Deal {
+  id: string;
+  productName: string;
+  currentPrice: number;
+  originalPrice: number;
+  discountPercent: number;
+  hook: string;
+  deadline?: string;
+  badge?: string;
+  color?: string;
+  ctaLabel?: string;
+}
+
+type DealInput = Omit<Deal, "badge" | "color" | "ctaLabel"> &
+  Partial<Pick<Deal, "badge" | "color" | "ctaLabel">>;
+
+const DEFAULT_DEAL_VALUES: Required<Pick<Deal, "badge" | "color" | "ctaLabel">> = {
+  badge: "Promo",
+  color: "from-slate-900/70 to-slate-800/70",
+  ctaLabel: "Profiter de l'offre →",
+};
+
+const defineDeal = (deal: DealInput): Deal => ({
+  ...DEFAULT_DEAL_VALUES,
+  ...deal,
+});
+
+export const deals: Deal[] = [
+  defineDeal({
+    id: "whey-isolate-2kg",
+    productName: "Whey Isolate 2kg",
+    currentPrice: 47.9,
+    originalPrice: 72.9,
+    discountPercent: 34,
+    hook: "Isolat de whey premium + shaker offert chez OptiPower.",
+    badge: "Top Deal",
+    color: "from-orange-500/80 to-red-500/80",
+    deadline: new Date(Date.now() + 1000 * 60 * 60 * 48).toISOString(),
+  }),
+  defineDeal({
+    id: "creatine-monohydrate-500g",
+    productName: "Créatine Monohydrate 500g",
+    currentPrice: 14.9,
+    originalPrice: 24.9,
+    discountPercent: 40,
+    hook: "Stock limité : livraison express offerte dès 2 pots.",
+    badge: "Flash",
+    color: "from-blue-500/80 to-cyan-500/80",
+    deadline: new Date(Date.now() + 1000 * 60 * 60 * 5).toISOString(),
+  }),
+  defineDeal({
+    id: "lifting-belt-premium",
+    productName: "Ceinture de force premium cuir",
+    currentPrice: 59.9,
+    originalPrice: 79.9,
+    discountPercent: 25,
+    hook: "Conçue pour le powerlifting : double couture renforcée.",
+    badge: "Accessoires",
+    color: "from-purple-500/80 to-pink-500/80",
+  }),
+];


### PR DESCRIPTION
## Summary
- introduit un module de données pour décrire les offres promotionnelles avec valeurs par défaut
- met à jour la section Promotions pour afficher prix barrés, badge de remise et compte à rebours dynamique

## Testing
- npm run lint *(échoue : Invalid option '--ext' avec eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68de4587dbc483259283ed36c1d62188