### PR TITLE
Add price alert form and API endpoint

### DIFF
--- a/frontend/src/app/api/alerts/route.ts
+++ b/frontend/src/app/api/alerts/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+
+interface PriceAlertPayload {
+  email?: string;
+  product?: string;
+  priceThreshold?: number;
+}
+
+export async function POST(request: Request) {
+  let payload: PriceAlertPayload;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json({ message: "Format JSON invalide." }, { status: 400 });
+  }
+
+  const { email, product, priceThreshold } = payload;
+
+  if (!email || !product || typeof priceThreshold !== "number" || Number.isNaN(priceThreshold)) {
+    return NextResponse.json(
+      { message: "Informations manquantes pour créer l'alerte." },
+      { status: 400 }
+    );
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json({ message: "Adresse e-mail invalide." }, { status: 400 });
+  }
+
+  if (priceThreshold <= 0) {
+    return NextResponse.json(
+      { message: "Le seuil de prix doit être supérieur à zéro." },
+      { status: 400 }
+    );
+  }
+
+  console.info("[PriceAlert]", {
+    email,
+    product,
+    priceThreshold,
+    timestamp: new Date().toISOString(),
+  });
+
+  return NextResponse.json(
+    {
+      message: "Alerte prix enregistrée.",
+    },
+    { status: 201 }
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,7 @@ import { HeroSection } from "@/components/HeroSection";
 import { DealsShowcase } from "@/components/DealsShowcase";
 import { ComparatorSummary, Category } from "@/components/ComparatorSummary";
 import { PriceAlertsSection } from "@/components/PriceAlertsSection";
+import { PriceAlertForm } from "@/components/PriceAlertForm";
 
 const categories: Category[] = [
   { titre: "Whey Protein", query: "whey protein", icon: "💪", bg: "bg-orange-500" },
@@ -68,6 +69,32 @@ export default function Home() {
         <DealsShowcase />
         <ComparatorSummary categories={categories} onSelectCategory={handleSelectCategory} />
         <PriceAlertsSection onExploreCatalogue={handleExploreCatalogue} />
+        <section id="alertes-prix" className="bg-[#0b1320] py-20">
+          <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-2 lg:items-start">
+            <div className="space-y-6">
+              <h2 className="text-3xl sm:text-4xl font-bold text-white">Alertes prix personnalisées</h2>
+              <p className="text-lg text-gray-200">
+                Configurez un suivi précis de vos compléments favoris. Nous analysons les marchands via
+                SerpAI et vous envoyons un e-mail instantané dès qu'un prix passe sous votre seuil.
+              </p>
+              <ul className="space-y-3 text-gray-300">
+                <li className="flex items-start gap-3">
+                  <span className="text-orange-400">•</span>
+                  Surveillance quotidienne des variations de prix multi-boutiques.
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="text-orange-400">•</span>
+                  Alertes déclenchées automatiquement via les flux SerpAI et historisation interne.
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="text-orange-400">•</span>
+                  Option de désinscription en un clic dans chaque notification.
+                </li>
+              </ul>
+            </div>
+            <PriceAlertForm />
+          </div>
+        </section>
       </main>
 
       <footer className="bg-[#0d1b2a] py-6 text-center text-sm text-gray-400">

--- a/frontend/src/components/PriceAlertForm.tsx
+++ b/frontend/src/components/PriceAlertForm.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useCallback, useMemo, useState } from "react";
+
+interface FormState {
+  email: string;
+  product: string;
+  priceThreshold: string;
+}
+
+interface FormErrors {
+  email?: string;
+  product?: string;
+  priceThreshold?: string;
+}
+
+interface SubmissionStatus {
+  state: "idle" | "loading" | "success" | "error";
+  message?: string;
+}
+
+const initialState: FormState = {
+  email: "",
+  product: "",
+  priceThreshold: "",
+};
+
+export function PriceAlertForm() {
+  const [formState, setFormState] = useState<FormState>(initialState);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [status, setStatus] = useState<SubmissionStatus>({ state: "idle" });
+
+  const isSubmitting = status.state === "loading";
+
+  const emailRegex = useMemo(() => /^[^\s@]+@[^\s@]+\.[^\s@]+$/, []);
+
+  const validate = useCallback(
+    (state: FormState): FormErrors => {
+      const currentErrors: FormErrors = {};
+
+      if (!state.email) {
+        currentErrors.email = "L'e-mail est requis.";
+      } else if (!emailRegex.test(state.email)) {
+        currentErrors.email = "Veuillez entrer un e-mail valide.";
+      }
+
+      if (!state.product.trim()) {
+        currentErrors.product = "Indiquez le produit que vous souhaitez suivre.";
+      }
+
+      const parsedThreshold = Number.parseFloat(state.priceThreshold.replace(",", "."));
+      if (!state.priceThreshold) {
+        currentErrors.priceThreshold = "Le seuil est requis.";
+      } else if (Number.isNaN(parsedThreshold) || parsedThreshold <= 0) {
+        currentErrors.priceThreshold = "Saisissez un montant supérieur à 0.";
+      }
+
+      return currentErrors;
+    },
+    [emailRegex]
+  );
+
+  const handleChange = useCallback((key: keyof FormState) => {
+    return (event: ChangeEvent<HTMLInputElement>) => {
+      setFormState((prev) => ({ ...prev, [key]: event.target.value }));
+      setErrors((prev) => ({ ...prev, [key]: undefined }));
+      if (status.state !== "idle") {
+        setStatus({ state: "idle" });
+      }
+    };
+  }, [status.state]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const validationErrors = validate(formState);
+      if (Object.keys(validationErrors).length > 0) {
+        setErrors(validationErrors);
+        setStatus({ state: "error", message: "Veuillez corriger les erreurs ci-dessous." });
+        return;
+      }
+
+      setStatus({ state: "loading" });
+
+      try {
+        const response = await fetch("/api/alerts", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: formState.email.trim(),
+            product: formState.product.trim(),
+            priceThreshold: Number.parseFloat(formState.priceThreshold.replace(",", ".")),
+          }),
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          const message = typeof data.message === "string" ? data.message : undefined;
+          throw new Error(message ?? "Impossible d'enregistrer votre alerte pour le moment.");
+        }
+
+        setStatus({
+          state: "success",
+          message: "Votre alerte a été enregistrée ! Nous vous préviendrons dès que le prix baisse.",
+        });
+        setFormState(initialState);
+        setErrors({});
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Une erreur inattendue est survenue.";
+        setStatus({ state: "error", message });
+      }
+    },
+    [formState, validate]
+  );
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-6 rounded-3xl border border-white/10 bg-[#0d1b2a] p-8 shadow-lg"
+      noValidate
+    >
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <label htmlFor="alert-email" className="block text-sm font-medium text-gray-200">
+            Adresse e-mail
+          </label>
+          <input
+            id="alert-email"
+            type="email"
+            inputMode="email"
+            autoComplete="email"
+            value={formState.email}
+            onChange={handleChange("email")}
+            className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-500/40"
+            placeholder="vous@exemple.com"
+            required
+          />
+          {errors.email && <p className="mt-2 text-sm text-red-400">{errors.email}</p>}
+        </div>
+
+        <div className="sm:col-span-2">
+          <label htmlFor="alert-product" className="block text-sm font-medium text-gray-200">
+            Produit ciblé
+          </label>
+          <input
+            id="alert-product"
+            type="text"
+            value={formState.product}
+            onChange={handleChange("product")}
+            className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-500/40"
+            placeholder="Ex. Whey Native Chocolat 1kg"
+            required
+          />
+          {errors.product && <p className="mt-2 text-sm text-red-400">{errors.product}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="alert-threshold" className="block text-sm font-medium text-gray-200">
+            Seuil de prix (€)
+          </label>
+          <input
+            id="alert-threshold"
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="0.01"
+            value={formState.priceThreshold}
+            onChange={handleChange("priceThreshold")}
+            className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-500/40"
+            placeholder="Ex. 24.90"
+            required
+          />
+          {errors.priceThreshold && (
+            <p className="mt-2 text-sm text-red-400">{errors.priceThreshold}</p>
+          )}
+        </div>
+      </div>
+
+      {status.state !== "idle" && status.message && (
+        <p
+          className={`text-sm ${
+            status.state === "success" ? "text-emerald-300" : "text-red-400"
+          }`}
+        >
+          {status.message}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        className="w-full rounded-full bg-orange-500 px-6 py-3 font-semibold text-white transition-colors hover:bg-orange-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-300 disabled:cursor-not-allowed disabled:opacity-70"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "Enregistrement..." : "Créer l'alerte"}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side price alert form component with validation and user feedback
- create a mock Next.js API endpoint to record price alert requests
- expose the new alertes prix section on the home page describing SerpAI-powered notifications

## Testing
- npm run lint *(fails: ESLint configuration next/core-web-vitals is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de464f6a2883259500a510327e8925