### PR TITLE
Delay deal countdown initialization until client mount

### DIFF
--- a/frontend/src/components/DealsShowcase.tsx
+++ b/frontend/src/components/DealsShowcase.tsx
@@ -34,21 +34,19 @@ const formatRemainingTime = (deadline: string) => {
 };
 
 function useDealCountdown(deadline?: string) {
-  const [remaining, setRemaining] = useState(() =>
-    deadline ? formatRemainingTime(deadline) : undefined
-  );
+  const [remaining, setRemaining] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     if (!deadline) {
       return;
     }
 
-    const tick = () => {
+    const update = () => {
       setRemaining(formatRemainingTime(deadline));
     };
 
-    tick();
-    const interval = window.setInterval(tick, 1000);
+    update();
+    const interval = window.setInterval(update, 1000);
 
     return () => window.clearInterval(interval);
   }, [deadline]);


### PR DESCRIPTION
## Summary
- initialize the deal countdown state as undefined to avoid server/client mismatches
- trigger the initial countdown update from the effect so it starts after the component mounts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de4c29f37c83259ac718c15385c76e