### PR TITLE
Add hero search form with popular suggestions

### DIFF
--- a/frontend/src/components/HeroSection.tsx
+++ b/frontend/src/components/HeroSection.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { useRouter } from "next/navigation";
+import { FormEvent, useCallback, useMemo, useState } from "react";
 
 interface HeroSectionProps {
   onStartComparison: () => void;
@@ -8,6 +10,34 @@ interface HeroSectionProps {
 }
 
 export function HeroSection({ onStartComparison, onViewDeals }: HeroSectionProps) {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const popularSearches = useMemo(
+    () => ["Whey isolate chocolat", "Protéine vegan", "Optimum Nutrition", "Isolate sans lactose"],
+    [],
+  );
+
+  const handleSearch = useCallback(
+    (query?: string) => {
+      const trimmedQuery = (query ?? searchQuery).trim();
+      if (!trimmedQuery) {
+        return;
+      }
+
+      router.push(`/comparateur?q=${encodeURIComponent(trimmedQuery)}`);
+    },
+    [router, searchQuery],
+  );
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      handleSearch();
+    },
+    [handleSearch],
+  );
+
   return (
     <section className="relative overflow-hidden py-24 bg-gradient-to-br from-[#0d1b2a] via-[#1b263b] to-[#415a77] text-white">
       <div className="container mx-auto px-6">
@@ -25,7 +55,51 @@ export function HeroSection({ onStartComparison, onViewDeals }: HeroSectionProps
             Sport Comparator agrège les meilleures boutiques en ligne pour vous proposer
             des suppléments, équipements et tenues de sport au meilleur tarif, en temps réel.
           </p>
-          <div className="mt-10 flex flex-col sm:flex-row gap-4">
+          <form onSubmit={handleSubmit} className="mt-10 space-y-4">
+            <div>
+              <label htmlFor="hero-search" className="sr-only">
+                Recherche de compléments
+              </label>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <input
+                  id="hero-search"
+                  name="query"
+                  type="search"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="Recherchez une whey par marque, type ou objectif"
+                  className="w-full rounded-full border border-white/10 bg-white/90 px-6 py-4 text-base text-slate-900 placeholder:text-slate-500 shadow-lg focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
+                  aria-describedby="popular-searches"
+                />
+                <button
+                  type="submit"
+                  className="flex-shrink-0 rounded-full bg-orange-500 px-8 py-4 text-base font-semibold text-white shadow-lg transition-colors hover:bg-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200 focus:ring-offset-2 focus:ring-offset-slate-900"
+                >
+                  Rechercher
+                </button>
+              </div>
+            </div>
+            <div id="popular-searches" className="flex flex-wrap items-center gap-2 text-sm text-gray-200">
+              <span className="mr-2 font-medium uppercase tracking-wide text-xs text-orange-200">
+                Recherches populaires :
+              </span>
+              {popularSearches.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  onClick={() => {
+                    setSearchQuery(suggestion);
+                    handleSearch(suggestion);
+                  }}
+                  className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-orange-200 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-orange-200 focus:ring-offset-2 focus:ring-offset-slate-900"
+                  aria-label={`Rechercher ${suggestion}`}
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          </form>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4">
             <button
               onClick={onStartComparison}
               className="rounded-full bg-orange-500 hover:bg-orange-400 transition-colors px-8 py-3 font-semibold shadow-lg"


### PR DESCRIPTION
## Summary
- add a responsive search form with routing to the comparator page in the hero section
- surface accessible popular search chips that trigger the comparator query

## Testing
- npm run lint -- --dir frontend *(fails: eslint CLI option --ext is unsupported with flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68de75cf06ec83259bd964ca9fe107c4