### PR TITLE
feat: enrich deal cards with visuals and ratings

### DIFF
--- a/frontend/src/components/DealsShowcase.tsx
+++ b/frontend/src/components/DealsShowcase.tsx
@@ -54,6 +54,8 @@ function useDealCountdown(deadline?: string) {
   return remaining;
 }
 
+const starArray = Array.from({ length: 5 });
+
 function DealCard({ deal, index }: { deal: Deal; index: number }) {
   const countdown = useDealCountdown(deal.deadline);
   const discountBadge = useMemo(
@@ -68,21 +70,63 @@ function DealCard({ deal, index }: { deal: Deal; index: number }) {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}
       transition={{ delay: index * 0.1 }}
-      className={`relative overflow-hidden rounded-2xl bg-gradient-to-br ${deal.color} p-6 shadow-lg`}
+      className={`relative flex h-full flex-col overflow-hidden rounded-2xl bg-gradient-to-br ${deal.color} p-6 shadow-lg`}
     >
-      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wider text-white/80">
-        <span className="inline-flex items-center gap-2 rounded-full bg-black/30 px-3 py-1">
-          {deal.badge}
-        </span>
+      <div className="flex flex-wrap items-center justify-between gap-3 text-xs font-semibold uppercase tracking-wider text-white/80">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center gap-2 rounded-full bg-black/30 px-3 py-1">
+            {deal.badge}
+          </span>
+          {deal.bestPrice && (
+            <span
+              className="inline-flex items-center gap-2 rounded-full bg-lime-300/90 px-3 py-1 text-slate-900"
+              aria-label="Meilleur prix actuel"
+            >
+              🏆 Meilleur prix
+            </span>
+          )}
+        </div>
         <span className="inline-flex items-center gap-1 rounded-full bg-black/30 px-3 py-1">
           {discountBadge}
         </span>
       </div>
-      <h3 className="mt-4 text-2xl font-semibold text-white">
+      <div className="mt-5 overflow-hidden rounded-xl bg-black/20">
+        <img
+          src={deal.imageUrl}
+          alt={deal.imageAlt}
+          className="h-48 w-full object-cover object-center sm:h-52"
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
+      <h3 className="mt-5 text-2xl font-semibold text-white">
         {deal.productName}
       </h3>
       <p className="mt-3 text-sm text-white/90">{deal.hook}</p>
-      <div className="mt-6 flex items-end gap-3 text-white">
+      <div
+        className="mt-4 flex flex-wrap items-center gap-2 text-white"
+        aria-label={`Note ${deal.rating.toFixed(1)} sur 5 basée sur ${deal.reviewCount} avis`}
+      >
+        <div className="flex items-center gap-0.5" aria-hidden="true">
+          {starArray.map((_, starIndex) => {
+            const isFilled = starIndex + 1 <= Math.round(deal.rating);
+
+            return (
+              <span
+                key={`${deal.id}-star-${starIndex}`}
+                className={isFilled ? "text-yellow-300" : "text-white/40"}
+              >
+                ★
+              </span>
+            );
+          })}
+        </div>
+        <span className="text-sm font-medium">{deal.rating.toFixed(1)}</span>
+        <span className="text-xs text-white/70">
+          ({deal.reviewCount.toLocaleString("fr-FR")} avis)
+        </span>
+      </div>
+      <div className="mt-5 flex items-end gap-3 text-white">
         <span className="text-3xl font-bold">
           {priceFormatter.format(deal.currentPrice)}
         </span>

--- a/frontend/src/data/deals.ts
+++ b/frontend/src/data/deals.ts
@@ -9,10 +9,15 @@ export interface Deal {
   badge?: string;
   color?: string;
   ctaLabel?: string;
+  imageUrl: string;
+  imageAlt: string;
+  bestPrice: boolean;
+  rating: number;
+  reviewCount: number;
 }
 
-type DealInput = Omit<Deal, "badge" | "color" | "ctaLabel"> &
-  Partial<Pick<Deal, "badge" | "color" | "ctaLabel">>;
+type DealInput = Omit<Deal, "badge" | "color" | "ctaLabel" | "bestPrice"> &
+  Partial<Pick<Deal, "badge" | "color" | "ctaLabel" | "bestPrice">>;
 
 const DEFAULT_DEAL_VALUES: Required<Pick<Deal, "badge" | "color" | "ctaLabel">> = {
   badge: "Promo",
@@ -22,6 +27,7 @@ const DEFAULT_DEAL_VALUES: Required<Pick<Deal, "badge" | "color" | "ctaLabel">> 
 
 const defineDeal = (deal: DealInput): Deal => ({
   ...DEFAULT_DEAL_VALUES,
+  bestPrice: false,
   ...deal,
 });
 
@@ -36,6 +42,12 @@ export const deals: Deal[] = [
     badge: "Top Deal",
     color: "from-orange-500/80 to-red-500/80",
     deadline: new Date(Date.now() + 1000 * 60 * 60 * 48).toISOString(),
+    imageUrl:
+      "https://images.unsplash.com/photo-1549561434-d2059f2ff538?auto=format&fit=crop&w=600&q=80",
+    imageAlt: "Pot de whey isolate 2kg posé sur un plan de travail sportif",
+    bestPrice: true,
+    rating: 4.8,
+    reviewCount: 276,
   }),
   defineDeal({
     id: "creatine-monohydrate-500g",
@@ -47,6 +59,11 @@ export const deals: Deal[] = [
     badge: "Flash",
     color: "from-blue-500/80 to-cyan-500/80",
     deadline: new Date(Date.now() + 1000 * 60 * 60 * 5).toISOString(),
+    imageUrl:
+      "https://images.unsplash.com/photo-1585238341986-410252206994?auto=format&fit=crop&w=600&q=80",
+    imageAlt: "Sachet de créatine monohydrate posé à côté d'une cuillère doseuse",
+    rating: 4.6,
+    reviewCount: 198,
   }),
   defineDeal({
     id: "lifting-belt-premium",
@@ -57,5 +74,10 @@ export const deals: Deal[] = [
     hook: "Conçue pour le powerlifting : double couture renforcée.",
     badge: "Accessoires",
     color: "from-purple-500/80 to-pink-500/80",
+    imageUrl:
+      "https://images.unsplash.com/photo-1600180758890-6d9be482e1d7?auto=format&fit=crop&w=600&q=80",
+    imageAlt: "Ceinture de force en cuir marron avec boucle métallique",
+    rating: 4.9,
+    reviewCount: 412,
   }),
 ];


### PR DESCRIPTION
## Summary
- enrich deal seed data with product imagery, ratings, review counts, and best-price metadata
- refresh DealCard layout to surface images, highlight best price badges, display percentage discounts, and render accessible rating details

## Testing
- npm run lint *(fails: Invalid option '--ext' when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68de77f1e68c8325a4a58f83d81c73c3