### PR TITLE
Handle LastPass hydration warning in price alert form

### DIFF
--- a/frontend/src/components/PriceAlertForm.tsx
+++ b/frontend/src/components/PriceAlertForm.tsx
@@ -121,10 +121,11 @@ export function PriceAlertForm() {
     <form
       onSubmit={handleSubmit}
       className="space-y-6 rounded-3xl border border-white/10 bg-[#0d1b2a] p-8 shadow-lg"
+      autoComplete="off"
       noValidate
     >
       <div className="grid gap-5 sm:grid-cols-2">
-        <div className="sm:col-span-2">
+        <div className="sm:col-span-2" suppressHydrationWarning>
           <label htmlFor="alert-email" className="block text-sm font-medium text-gray-200">
             Adresse e-mail
           </label>
@@ -133,6 +134,7 @@ export function PriceAlertForm() {
             type="email"
             inputMode="email"
             autoComplete="email"
+            data-lpignore="true"
             value={formState.email}
             onChange={handleChange("email")}
             className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-500/40"


### PR DESCRIPTION
## Summary
- suppress hydration mismatches on the email field container to tolerate LastPass DOM injections
- disable form autocomplete and flag the email input for password managers to avoid icon insertion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de83b18e888325a81e26a23e36d831