### PR TITLE
Adjust homepage spacing and highlight partners

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -108,12 +108,12 @@ export default function Home() {
         )}
       </header>
 
-      <main>
+      <main className="pt-20 sm:pt-24">
         <HeroSection onStartComparison={handleStartComparison} onViewDeals={handleViewDeals} />
         <PopularCategories onSelectCategory={handleSelectCategory} />
         <DealsShowcase />
         <StatsSection />
-
+        <PartnerLogos />
         <WhyChooseUsSection />
 
         <PriceAlertsSection onExploreCatalogue={handleExploreCatalogue} />


### PR DESCRIPTION
## Summary
- add top padding to the main content to avoid overlap with the sticky header
- render the partner logos section between the promotions and value proposition blocks

## Testing
- npm run lint *(fails: unable to install dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8522f1f88325907bd50a3f74b7e6