### PR TITLE
Add React Query and Recharts dependencies to frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,9 @@
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "@tanstack/react-query": "^5.45.0",
+    "recharts": "^2.9.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add @tanstack/react-query and recharts as frontend runtime dependencies

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68df9d951f2c832598feeaf8d25212be