### PR TITLE
Fix local TanStack links in frontend lockfile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,11 +29,11 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "resolved": "file:vendor/tanstack-query-core",
+      "resolved": "vendor/tanstack-query-core",
       "link": true
     },
     "node_modules/@tanstack/react-query": {
-      "resolved": "file:vendor/tanstack-react-query",
+      "resolved": "vendor/tanstack-react-query",
       "link": true,
       "dependencies": {
         "@tanstack/query-core": "file:vendor/tanstack-query-core"


### PR DESCRIPTION
## Summary
- fix the TanStack vendor entries in the frontend lockfile so npm treats them as local links

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dfc69063548325b9ac68a5546d6baf