### PR TITLE
Configure turbopack root for Next.js

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  turbopack: {
+    root: __dirname,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add a turbopack root configuration to Next.js so it uses the frontend directory

## Testing
- npm run dev *(fails: `next` command not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcdc9ca1c83258f62a9e1c52270bb