### PR TITLE
Fix Turbopack root path configuration

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,9 +1,10 @@
+import path from "path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
   turbopack: {
-    root: __dirname,
+    root: path.resolve(__dirname, ".."),
   },
 };
 


### PR DESCRIPTION
## Summary
- update the Turbopack root override in `frontend/next.config.ts` to resolve from the monorepo root so shared dependencies can be discovered

## Testing
- `npm run dev` *(fails: Next.js CLI not installed because dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd546cd048325b621177fc46176e0