### PR TITLE
Add LastPass ignore attribute to newsletter form

### DIFF
--- a/frontend/src/components/SiteFooter.tsx
+++ b/frontend/src/components/SiteFooter.tsx
@@ -123,7 +123,14 @@ export function SiteFooter() {
               <p className="text-sm text-gray-400">
                 Recevez chaque semaine les meilleures promotions et astuces pour optimiser vos performances.
               </p>
-              <form noValidate onSubmit={handleSubmit} className="space-y-3" aria-describedby="newsletter-feedback">
+              <form
+                noValidate
+                onSubmit={handleSubmit}
+                className="space-y-3"
+                aria-describedby="newsletter-feedback"
+                data-lpignore="true"
+                autoComplete="off"
+              >
                 <div className="space-y-2">
                   <label htmlFor="newsletter-email" className="text-sm font-medium text-gray-200">
                     Adresse e-mail


### PR DESCRIPTION
## Summary
- add data-lpignore to the newsletter form so password managers skip injecting extra fields
- disable autocomplete on the newsletter signup form to avoid hydration mismatches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe6ca4c5c832599c0128cebbc24f7