### PR TITLE
feat: add related product suggestions

### DIFF
--- a/docs/recommandations-ameliorees.md
+++ b/docs/recommandations-ameliorees.md
@@ -1,0 +1,62 @@
+# Plan d'amélioration Whey Comparator (vs Idealo)
+
+## 1. Corrections des constats initiaux
+Les éléments suivants sont déjà implémentés ou partiellement livrés :
+
+- **Historique de prix complet** : l'API principale expose `/products/{product_id}/price-history` avec agrégation (période, stats) et s'appuie sur le service scraper pour requêter la table `price_history`. 【F:main.py†L201-L228】【F:main.py†L908-L980】【F:services/scraper/src/scraper/database.py†L21-L85】【F:services/scraper/src/scraper/main.py†L64-L87】
+- **Visualisation front** : le composant `PriceHistoryChart` affiche un AreaChart Recharts avec choix de période et indicateurs, utilisé sur la page produit. 【F:frontend/src/components/PriceHistoryChart.tsx†L1-L175】【F:frontend/src/app/products/[productId]/page.tsx†L45-L148】
+- **Filtres et tri avancés** : `/products` accepte prix min/max, marques, note, disponibilité, catégorie et différents tris (prix, note, ratio protéine/€). L'IU propose une sidebar interactive, un dropdown de tri, pagination et compte des résultats. 【F:main.py†L779-L880】【F:frontend/src/app/products/page.tsx†L1-L220】【F:frontend/src/components/FilterSidebar.tsx†L1-L197】【F:frontend/src/components/SortDropdown.tsx†L1-L34】
+- **Comparaison multi-produits** : la page `/comparison` synthétise les meilleures offres et le détail produit/offres, réutilise les composants communs et gère les états de chargement/erreur. 【F:frontend/src/app/comparison/page.tsx†L1-L120】
+- **Tableau des offres enrichi** : affichage des frais de port, badge "Meilleur prix", ratio €/kg, disponibilité et CTA externe sont déjà présents. 【F:frontend/src/components/OfferTable.tsx†L1-L120】
+
+Ces fondations sont solides : le plan d'action doit donc se concentrer sur les vrais écarts fonctionnels, la robustesse et la finition UI.
+
+## 2. Écarts réels et opportunités
+
+### 2.1 Fiabilité & scalabilité backend
+| Problème | Impact | Recommandation |
+| --- | --- | --- |
+| Filtrage/tri réalisés en mémoire après un fetch HTTP vers le scraper | Montée en charge limitée, tri partiel (pas de popularité, de disponibilité cross-fournisseurs). | Déporter les filtres/tri dans le service scraper (SQL) et ne transférer que la page courante ; ajouter champs `popularity`, `lastPriceDrop` pour enrichir le tri. 【F:main.py†L792-L880】 |
+| Absence de cache / fallback si le scraper est indisponible | Sensibilité aux pannes réseau ; SLA fragile. | Ajouter une couche de cache (Redis) côté FastAPI pour les listes/price history, et renvoyer le dernier snapshot valide en cas d'échec. |
+| Alertes prix côté Next.js ne font que logguer (pas de persistance). | Feature marketing non fonctionnelle, impossible d'envoyer des emails. | Exposer un endpoint FastAPI `/alerts` qui écrit en base + déclenche une file (ex : Redis/worker) ; faire pointer la route Next.js vers cette API. 【F:frontend/src/app/api/alerts/route.ts†L1-L52】 |
+| Pas de recalcul automatique de l'historique (uniquement via collecteurs). | Historique potentiellement creux selon les horaires de scraping. | Planifier un job (celery/APScheduler) pour normaliser les données (agrégation quotidienne, déduplication, interpolation pour les jours manquants). |
+
+### 2.2 Expérience Produit & UI
+| Manque | Pourquoi c'est important | Proposition |
+| --- | --- | --- |
+| Pas de recommandations/similaires en bas de la page produit. | Idéal pour cross-sell et pour rapprocher l'expérience d'Idealo. | Ajouter `/products/{id}/related` (basé sur marque, catégorie, profil nutritionnel) et une section "Produits alternatifs" sur la page produit. |
+| Comparaison : aucune mise en avant des gagnants par critère. | L'utilisateur doit parcourir chaque tableau pour comprendre. | Ajouter un bandeau de synthèse (meilleur prix, meilleur ratio, meilleure note) et coloration des cellules gagnantes. 【F:frontend/src/app/comparison/page.tsx†L84-L113】 |
+| Page catalogue : pas de sauvegarde des filtres (localStorage) ni d'URL partageable du comparateur. | UX perfectible, friction sur mobile. | Persister les filtres localement, proposer un bouton "Copier l'URL de comparaison" et ajouter un mode liste sur mobile. |
+| Page produit : pas de timeline des variations (sparkline) dans le header, ni d'indicateur de tendance. | Les visiteurs veulent savoir si le prix actuel est intéressant sans scroller. | Résumer `statistics` dans le hero (badge "-12% vs 30 jours", tendance flèche). 【F:main.py†L975-L979】【F:frontend/src/components/PriceHistoryChart.tsx†L158-L172】 |
+| Avis utilisateurs : seule l'offre principale remonte rating/count. | Moins riche qu'Idealo qui compile des avis. | Étendre le scraper pour collecter les avis SerpAPI + Amazon et afficher un agrégat + extraits (top positif/négatif). |
+
+### 2.3 Données & différenciation
+- **Indice nutritionnel** : calculer protéines/sucres par dose et synthèse "score performance" pour mieux comparer au-delà du prix. Les attributs existent partiellement via le scraper (`protein_per_serving_g`, `serving_size_g`). 【F:frontend/src/components/ProductCard.tsx†L10-L72】
+- **Analyse des frais de livraison** : stocker `shipping_cost`/`shipping_text` dans la base (déjà prévus côté modèle) mais enrichir l'algorithme pour estimer le coût total (TTC + port) et afficher un graphe comparatif. 【F:services/scraper/src/scraper/database.py†L42-L75】【F:frontend/src/components/OfferTable.tsx†L21-L78】
+- **Transparence des sources** : l'encart "Flux de données" est statique. Automatiser la liste des collectes récentes + statut du scraper, et afficher un badge "MAJ il y a X min". 【F:frontend/src/app/products/[productId]/page.tsx†L98-L148】
+
+## 3. Priorisation recommandée (vision 3 semaines)
+
+1. **Fiabiliser l'infra (Semaine 1)**
+   - Migrer le filtrage/tri dans le scraper (SQL + pagination), mettre en place un cache Redis côté FastAPI.
+   - Créer l'API d'alertes (FastAPI + stockage) et remplacer la route Next.js par un appel serveur → backend.
+   - Ajouter un job cron (APScheduler) dans le scraper pour densifier `price_history` et recalculer les stats quotidiennes.
+
+2. **Accentuer la valeur utilisateur (Semaine 2)**
+   - Ajouter `related products` et "section tendances" sur la page produit.
+   - Bonifier la comparaison : surlignage des meilleures valeurs, export partageable, compteur d'items comparés.
+   - Mettre à jour le header produit avec badge tendance (hausse/baisse vs période sélectionnée).
+
+3. **Différenciation / Delight (Semaine 3)**
+   - Centraliser les avis multi-sources + affichage sur carte produit et comparateur.
+   - Implémenter un tableau nutritionnel/score et un graphe comparatif des frais de livraison.
+   - Industrialiser les alertes prix (envoi email via worker) et notifier dans l'IU (toasts + historique des alertes).
+
+## 4. Mesures de succès
+- Taux de disponibilité API > 99 % grâce au cache et au fallback.
+- Temps de réponse `/products` < 500 ms p95 après migration SQL.
+- +20 % de clics sur comparateur suite à la mise en avant des gagnants.
+- ≥ 30 % des pages produit avec recommandations similaires cliquées.
+- Conversion des alertes : > 25 % des utilisateurs qui créent une alerte reviennent via email.
+
+Ce plan capitalise sur ce qui est déjà en place tout en comblant les vrais écarts fonctionnels face à Idealo.

--- a/frontend/src/app/products/[productId]/page.tsx
+++ b/frontend/src/app/products/[productId]/page.tsx
@@ -6,7 +6,7 @@ import { ProductCard } from "@/components/ProductCard";
 import { PriceHistoryChart } from "@/components/PriceHistoryChart";
 import { SiteFooter } from "@/components/SiteFooter";
 import apiClient from "@/lib/apiClient";
-import type { ProductOffersResponse } from "@/types/api";
+import type { ProductOffersResponse, RelatedProductsResponse } from "@/types/api";
 
 interface ProductDetailPageProps {
   params: { productId: string };
@@ -29,6 +29,23 @@ async function fetchProductOffers(productId: number) {
   }
 }
 
+async function fetchRelatedProducts(productId: number, limit = 4) {
+  try {
+    const related = await apiClient.get<RelatedProductsResponse>(
+      `/products/${productId}/related`,
+      {
+        query: { limit },
+        cache: "no-store",
+      },
+    );
+
+    return related;
+  } catch (error) {
+    console.error("Erreur chargement produits similaires", error);
+    return null;
+  }
+}
+
 export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
   const productId = Number(params.productId);
 
@@ -44,6 +61,8 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
 
   const { product, offers, sources } = data;
   const bestOffer = offers.find((offer) => offer.isBestPrice || offer.bestPrice) ?? offers[0];
+  const related = await fetchRelatedProducts(product.id, 4);
+  const relatedProducts = related?.related ?? [];
 
   return (
     <div className="min-h-screen bg-[#0b1320] text-white">
@@ -143,6 +162,36 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
                     {bestOffer.shippingText && <p className="mt-2">Livraison : {bestOffer.shippingText}</p>}
                     <p className="mt-2">Total TTC : {bestOffer.totalPrice?.formatted ?? bestOffer.price.formatted}</p>
                   </div>
+                </div>
+              </section>
+            )}
+            {relatedProducts.length > 0 && (
+              <section className="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-6">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <h2 className="text-lg font-semibold text-white">Produits similaires</h2>
+                  <p className="text-xs text-gray-400">
+                    Basés sur la marque, la catégorie et la composition nutritionnelle.
+                  </p>
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {relatedProducts.map((relatedProduct) => (
+                    <ProductCard
+                      key={relatedProduct.id}
+                      product={relatedProduct}
+                      href={`/products/${relatedProduct.id}`}
+                      footer={
+                        <div className="flex items-center justify-between text-xs text-gray-400">
+                          <span>ID #{relatedProduct.id}</span>
+                          <Link
+                            href={`/comparison?ids=${product.id},${relatedProduct.id}`}
+                            className="inline-flex items-center gap-1 font-semibold text-orange-300 transition hover:text-orange-200"
+                          >
+                            Comparer →
+                          </Link>
+                        </div>
+                      }
+                    />
+                  ))}
                 </div>
               </section>
             )}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -100,6 +100,11 @@ export interface ProductOffersResponse {
   };
 }
 
+export interface RelatedProductsResponse {
+  productId: number;
+  related: ProductSummary[];
+}
+
 export interface ComparisonEntry {
   product: ProductSummary;
   offers: DealItem[];

--- a/main.py
+++ b/main.py
@@ -163,6 +163,13 @@ def matches_query(name: str, query: Optional[str]) -> bool:
     return all(term in normalized for term in terms)
 
 
+def tokenize_keywords(value: Optional[str]) -> set[str]:
+    if not value:
+        return set()
+    tokens = re.split(r"[^a-z0-9]+", value.lower())
+    return {token for token in tokens if len(token) >= 3}
+
+
 def fetch_scraper_products(limit: Optional[int] = None) -> List[Dict[str, Any]]:
     if not SCRAPER_BASE_URL:
         return []
@@ -672,6 +679,92 @@ def serialize_product(product: Dict[str, Any]) -> Dict[str, Any]:
     return {key: product.get(key) for key in keys}
 
 
+def compute_similarity_score(
+    base: Dict[str, Any], candidate: Dict[str, Any]
+) -> float:
+    score = 0.0
+
+    base_brand = (base.get("brand") or "").strip().lower()
+    candidate_brand = (candidate.get("brand") or "").strip().lower()
+    if base_brand and candidate_brand:
+        if base_brand == candidate_brand:
+            score += 3.0
+        elif base_brand in candidate_brand or candidate_brand in base_brand:
+            score += 1.5
+
+    base_category = (base.get("category") or "").strip().lower()
+    candidate_category = (candidate.get("category") or "").strip().lower()
+    if base_category and candidate_category and base_category == candidate_category:
+        score += 1.5
+
+    base_tokens = tokenize_keywords(base.get("name"))
+    candidate_tokens = tokenize_keywords(candidate.get("name"))
+    if base_tokens and candidate_tokens:
+        overlap = base_tokens & candidate_tokens
+        if overlap:
+            score += 2.0 * len(overlap) / max(len(base_tokens), 1)
+
+    base_flavour = tokenize_keywords(base.get("flavour"))
+    candidate_flavour = tokenize_keywords(candidate.get("flavour"))
+    if base_flavour and candidate_flavour:
+        flavour_overlap = base_flavour & candidate_flavour
+        if flavour_overlap:
+            score += 1.0
+
+    base_protein = parse_float(base.get("protein_per_serving_g"))
+    candidate_protein = parse_float(candidate.get("protein_per_serving_g"))
+    if (
+        base_protein is not None
+        and candidate_protein is not None
+        and abs(base_protein - candidate_protein) <= 2
+    ):
+        score += 0.5
+
+    return score
+
+
+def find_related_products(
+    products: List[Dict[str, Any]],
+    base_product: Dict[str, Any],
+    *,
+    limit: int,
+) -> List[Dict[str, Any]]:
+    base_id = base_product.get("id")
+    if base_id is None:
+        return []
+
+    scored_candidates: List[tuple[float, Dict[str, Any]]] = []
+    for candidate in products:
+        if candidate is base_product:
+            continue
+        candidate_id = candidate.get("id")
+        if candidate_id is None or candidate_id == base_id:
+            continue
+        score = compute_similarity_score(base_product, candidate)
+        if score <= 0:
+            continue
+        scored_candidates.append((score, candidate))
+
+    if not scored_candidates:
+        fallback = [
+            product
+            for product in products
+            if product is not base_product and product.get("id") != base_id
+        ]
+        scored_candidates = [(0.0, product) for product in fallback[: limit * 2]]
+    else:
+        scored_candidates.sort(key=lambda item: item[0], reverse=True)
+
+    related_summaries: List[Dict[str, Any]] = []
+    for _, candidate in scored_candidates:
+        summary = build_product_summary(candidate, offer_limit=6)
+        related_summaries.append(summary)
+        if len(related_summaries) >= limit:
+            break
+
+    return related_summaries
+
+
 def collect_scraper_deals(q: str, limit: int = 12) -> List[Dict[str, Any]]:
     deals: List[Dict[str, Any]] = []
     products = fetch_scraper_products()
@@ -926,6 +1019,32 @@ def product_offers_endpoint(
         "sources": {
             "scraper": scraper_offers,
         },
+    }
+
+
+@app.get("/products/{product_id}/related")
+def related_products_endpoint(
+    product_id: int,
+    limit: int = Query(4, ge=1, le=12),
+):
+    products = fetch_scraper_products()
+    base_product: Optional[Dict[str, Any]] = None
+    for product in products:
+        try:
+            if int(product.get("id")) == product_id:
+                base_product = product
+                break
+        except (TypeError, ValueError):
+            continue
+
+    if base_product is None:
+        raise HTTPException(status_code=404, detail="Produit introuvable")
+
+    related = find_related_products(products, base_product, limit=limit)
+
+    return {
+        "productId": product_id,
+        "related": related,
     }
 
 


### PR DESCRIPTION
## Summary
- compute related product recommendations in the FastAPI layer using brand, category and nutrition heuristics
- expose the recommendations through a new /products/{id}/related endpoint
- surface a "Produits similaires" section on the product detail page that links to comparison flows

## Testing
- npm run lint *(fails: missing eslint-plugin-react-refresh dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e38403671c832586cab44e9968e247