### PR TITLE
Refine comparison links across product pages

### DIFF
--- a/frontend/src/app/products/[productId]/page.tsx
+++ b/frontend/src/app/products/[productId]/page.tsx
@@ -13,6 +13,16 @@ interface ProductDetailPageProps {
   params: { productId: string };
 }
 
+function buildComparisonHref(...productIds: number[]): string {
+  const uniqueIds = Array.from(
+    new Set(productIds.filter((id) => Number.isFinite(id)).map((id) => String(id).trim())),
+  );
+
+  return uniqueIds.length > 0
+    ? `/comparison?ids=${encodeURIComponent(uniqueIds.join(","))}`
+    : "/comparison";
+}
+
 async function fetchProductOffers(productId: number) {
   try {
     const data = await apiClient.get<ProductOffersResponse>(
@@ -96,7 +106,7 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
             {product.brand && <p className="text-gray-300">{product.brand}</p>}
           </div>
           <CompareLinkButton
-            href={`/comparison?ids=${product.id}`}
+            href={buildComparisonHref(product.id)}
             className="rounded-full bg-orange-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300"
             aria-label={`Ajouter ${product.brand ? `${product.brand} ` : ""}${product.name} à la comparaison`}
             title={`Ajouter ${product.brand ? `${product.brand} ` : ""}${product.name} à la comparaison`}
@@ -186,7 +196,7 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
                         <div className="flex items-center justify-between text-xs text-gray-400">
                           <span>ID #{relatedProduct.id}</span>
                           <CompareLinkButton
-                            href={`/comparison?ids=${product.id},${relatedProduct.id}`}
+                            href={buildComparisonHref(product.id, relatedProduct.id)}
                             className="inline-flex items-center gap-1 font-semibold text-orange-300 transition hover:text-orange-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
                             aria-label={`Comparer ${product.brand ? `${product.brand} ` : ""}${product.name} avec ${relatedProduct.brand ? `${relatedProduct.brand} ` : ""}${relatedProduct.name}`}
                             title={`Comparer ${product.brand ? `${product.brand} ` : ""}${product.name} avec ${relatedProduct.brand ? `${relatedProduct.brand} ` : ""}${relatedProduct.name}`}

--- a/frontend/src/app/products/page.tsx
+++ b/frontend/src/app/products/page.tsx
@@ -15,6 +15,13 @@ import type { ProductSummary } from "@/types/api";
 
 const DEFAULT_PER_PAGE = 12;
 
+function buildComparisonHref(productIds: number[]): string {
+  const uniqueIds = Array.from(new Set(productIds.map((id) => String(id).trim())));
+  return uniqueIds.length > 0
+    ? `/comparison?ids=${encodeURIComponent(uniqueIds.join(","))}`
+    : "/comparison";
+}
+
 function parseNumberParam(value: string | null): number | null {
   if (!value) {
     return null;
@@ -310,7 +317,7 @@ export default function ProductsPage() {
                       <div className="flex items-center justify-between text-xs text-gray-400">
                         <span>ID #{product.id}</span>
                         <CompareLinkButton
-                          href={`/comparison?ids=${product.id}`}
+                          href={buildComparisonHref([product.id])}
                           className="inline-flex items-center gap-1 font-semibold text-orange-300 transition hover:text-orange-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
                           aria-label={`Comparer ${product.brand ? `${product.brand} ` : ""}${product.name}`}
                           title={`Comparer ${product.brand ? `${product.brand} ` : ""}${product.name}`}

--- a/frontend/src/components/CompareLinkButton.tsx
+++ b/frontend/src/components/CompareLinkButton.tsx
@@ -1,59 +1,57 @@
 "use client";
 
+import Link from "next/link";
 import {
+  forwardRef,
+  type AnchorHTMLAttributes,
   type MouseEvent,
-  type ReactNode,
-  type ButtonHTMLAttributes,
   useCallback,
 } from "react";
-import { useRouter } from "next/navigation";
 
 interface CompareLinkButtonProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type" | "onClick"> {
+  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
   href: string;
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-  children: ReactNode;
+  stopPropagation?: boolean;
 }
 
-export function CompareLinkButton({
-  href,
-  onClick,
-  className,
-  children,
-  ...props
-}: CompareLinkButtonProps) {
-  const router = useRouter();
-
-  const handleClick = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      if (onClick) {
-        onClick(event);
-        if (event.defaultPrevented) {
-          return;
+export const CompareLinkButton = forwardRef<
+  HTMLAnchorElement,
+  CompareLinkButtonProps
+>(
+  (
+    { href, stopPropagation = true, onClick, className, children, ...props },
+    ref,
+  ) => {
+    const handleClick = useCallback(
+      (event: MouseEvent<HTMLAnchorElement>) => {
+        if (stopPropagation) {
+          event.stopPropagation();
         }
-      }
 
-      event.preventDefault();
-      event.stopPropagation();
+        if (onClick) {
+          onClick(event);
+        }
+      },
+      [onClick, stopPropagation],
+    );
 
-      router.push(href);
-    },
-    [href, onClick, router],
-  );
+    const normalizedClassName =
+      typeof className === "string" && className.trim().length > 0
+        ? className.trim()
+        : className ?? undefined;
 
-  const buttonClassName =
-    typeof className === "string" && className.length > 0
-      ? className.trim()
-      : className;
+    return (
+      <Link
+        href={href}
+        ref={ref}
+        className={normalizedClassName}
+        onClick={handleClick}
+        {...props}
+      >
+        {children}
+      </Link>
+    );
+  },
+);
 
-  return (
-    <button
-      type="button"
-      className={buttonClassName}
-      onClick={handleClick}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-}
+CompareLinkButton.displayName = "CompareLinkButton";


### PR DESCRIPTION
## Summary
- replace the button-based CompareLinkButton with a link that preserves default navigation semantics while still stopping parent click handlers
- centralize comparison link generation for product listing and detail views to ensure consistent URL formatting

## Testing
- npm run lint *(fails: ESLint couldn't find the config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68e3be0fc08883258a24319c9d5cb6ac