### PR TITLE
Fix unbound best offer reference in SERP aggregation

### DIFF
--- a/main.py
+++ b/main.py
@@ -420,6 +420,7 @@ def collect_serp_deals(
 
     deals: List[Dict[str, Any]] = []
     for index, item in enumerate(shopping_results):
+        best: Optional[Dict[str, Any]] = None
         title = (item.get("title") or "").strip()
         title_lower = title.lower()
 


### PR DESCRIPTION
## Summary
- reset the best-offer placeholder for each Google Shopping result before enriching offers

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c8a6549c8325b81a6c04acf1aea5