### PR TITLE
Normalize scheme-relative image URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,6 +83,8 @@ def normalize_image_url(value: Any) -> Optional[str]:
     if isinstance(value, str):
         trimmed = value.strip()
         if trimmed:
+            if trimmed.startswith("//"):
+                return "https:" + trimmed
             return trimmed
     return None
 


### PR DESCRIPTION
## Summary
- ensure scheme-relative image URLs from the API are normalized to https so product pictures load correctly in browsers

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cff2e3d48325b176d9d677a7ea4c