### PR TITLE
Enhance product imagery fallbacks and comparison UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,6 +83,8 @@ def normalize_image_url(value: Any) -> Optional[str]:
     if isinstance(value, str):
         trimmed = value.strip()
         if trimmed:
+            if trimmed.startswith("//"):
+                return "https:" + trimmed
             return trimmed
     return None
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ProductFiltersSidebar } from './components/ProductFiltersSidebar';
 import { ProductComparisonTable } from './components/ProductComparisonTable';
 
 import { HighlightedDealsSection } from './components/HighlightedDealsSection';
+import { highlightedDeals } from './data/products';
 import { useProducts } from './hooks/useProducts';
 import { selectFilters, selectSelectedProductIds, useProductSelectionStore } from './store/productSelectionStore';
 import { usePriceAlertStore } from './store/priceAlertStore';

--- a/src/components/HighlightedDealsSection.tsx
+++ b/src/components/HighlightedDealsSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import type { HighlightedDeal, Product } from '../data/products';
+import { ProductImage } from './ProductImage';
 
 type HighlightedDealsSectionProps = {
   deals: HighlightedDeal[];
@@ -80,6 +81,12 @@ export const HighlightedDealsSection = ({ deals, products, isLoading }: Highligh
               className="flex h-full flex-col justify-between rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
             >
               <div className="space-y-3">
+                <ProductImage
+                  imageUrl={product.imageUrl}
+                  alt={product.imageAlt ?? product.name}
+                  className="h-40 w-full rounded-xl"
+                  fallbackLabel={`${product.brand} ${product.name}`}
+                />
                 <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary-600">
                   {product.badges.map((badge) => (
                     <span

--- a/src/components/ProductComparisonTable.tsx
+++ b/src/components/ProductComparisonTable.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 
 import type { Product } from '../data/products';
 import { useProductSelectionStore } from '../store/productSelectionStore';
+import { ProductImage } from './ProductImage';
 
 interface ProductComparisonTableProps {
   products: Product[];
@@ -154,66 +155,96 @@ export const ProductComparisonTable = ({ products, isLoading }: ProductCompariso
   }
 
   return (
-    <section className="rounded-2xl bg-white p-6 shadow-sm">
-      <div className="flex items-center justify-between">
+    <section className="space-y-6 rounded-2xl bg-white p-6 shadow-sm">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h2 className="text-lg font-semibold text-slate-900">Comparatif des produits</h2>
           <p className="text-sm text-slate-500">Colonnes dynamiques selon votre sélection.</p>
         </div>
+        <p className="text-xs text-slate-400">Retirez un produit pour libérer une place dans le comparateur.</p>
       </div>
 
-      <div className="mt-6 overflow-x-auto">
-        <table className="min-w-full text-left text-sm text-slate-700">
-          <thead>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {products.map((product) => (
+          <article
+            key={product.id}
+            className="flex h-full flex-col justify-between gap-4 rounded-xl border border-slate-200 bg-slate-50/80 p-4 shadow-sm"
+          >
+            <div className="flex items-start gap-3">
+              <ProductImage
+                imageUrl={product.imageUrl}
+                alt={product.imageAlt ?? product.name}
+                className="h-16 w-16 flex-shrink-0 rounded-xl border border-white shadow"
+                fallbackLabel={`${product.brand} ${product.name}`}
+              />
+              <div className="flex flex-1 flex-col">
+                <span className="text-xs font-semibold uppercase tracking-wide text-primary-600">{product.brand}</span>
+                <h3 className="text-base font-semibold text-slate-900">{product.name}</h3>
+                <span className="text-xs text-slate-500">{product.servings} portions • {product.flavor}</span>
+              </div>
+            </div>
+            <div className="flex items-end justify-between">
+              <div>
+                <p className="text-lg font-bold text-slate-900">{formatCurrency(product.price)}</p>
+                <p className="text-xs text-slate-500">
+                  {formatCurrency(product.price / product.servings)} / portion
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => toggleProductSelection(product.id)}
+                className="rounded-full border border-primary-200 px-3 py-1 text-xs font-medium text-primary-600 transition hover:border-primary-300 hover:bg-primary-50"
+              >
+                Retirer
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full table-auto border-collapse text-left text-sm text-slate-700">
+          <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
             <tr>
-              <th className="w-48 border-b border-slate-200 pb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Critère
-              </th>
+              <th className="w-48 px-4 py-3">Critère</th>
               {products.map((product) => (
-                <th
-                  key={product.id}
-                  className="border-b border-slate-200 pb-3 text-left text-base font-semibold text-slate-900"
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <div>{product.name}</div>
-                      <div className="text-xs text-slate-500">{product.brand}</div>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => toggleProductSelection(product.id)}
-                      className="text-xs font-medium text-primary-600 hover:text-primary-700"
-                    >
-                      Retirer
-                    </button>
-                  </div>
+                <th key={product.id} className="min-w-[160px] px-4 py-3 text-left">
+                  {product.name}
                 </th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => (
-              <tr key={row.label} className="border-b border-slate-100 last:border-0">
-                <th className="py-4 text-xs font-semibold uppercase tracking-wide text-slate-500">{row.label}</th>
+            {rows.map((row, rowIndex) => (
+              <tr
+                key={row.label}
+                className={`${rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50/70'} border-b border-slate-100 last:border-0`}
+              >
+                <th className="whitespace-nowrap px-4 py-4 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {row.label}
+                </th>
                 {products.map((product) => (
-                  <td key={product.id} className="py-4 pr-6">
+                  <td key={product.id} className="px-4 py-4 align-top text-slate-700">
                     {row.render(product)}
                   </td>
                 ))}
               </tr>
             ))}
-            <tr className="border-b border-slate-100">
-              <th className="py-4 text-xs font-semibold uppercase tracking-wide text-slate-500">Lien</th>
+            <tr className="border-b border-slate-100 bg-white">
+              <th className="whitespace-nowrap px-4 py-4 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Lien
+              </th>
               {products.map((product) => (
-                <td key={product.id} className="py-4">
+                <td key={product.id} className="px-4 py-4">
                   {product.link ? (
                     <a
                       href={product.link}
-                      className="text-sm font-medium text-primary-600 hover:text-primary-700"
+                      className="inline-flex items-center gap-2 text-sm font-medium text-primary-600 hover:text-primary-700"
                       target="_blank"
                       rel="noreferrer"
                     >
                       Voir le produit
+                      <span aria-hidden>↗</span>
                     </a>
                   ) : (
                     <span className="text-sm text-slate-400">Non renseigné</span>

--- a/src/components/ProductFiltersSidebar.tsx
+++ b/src/components/ProductFiltersSidebar.tsx
@@ -8,6 +8,7 @@ import {
   selectSelectedProductIds,
   useProductSelectionStore,
 } from '../store/productSelectionStore';
+import { ProductImage } from './ProductImage';
 
 interface ProductFiltersSidebarProps {
   allProducts: Product[];
@@ -191,26 +192,42 @@ export const ProductFiltersSidebar = ({
           <span className="text-xs text-slate-400">Comparer 2 à 4 produits</span>
         </div>
         <div className="space-y-2">
-          {filteredSelection.map(({ product, disabled }) => (
-            <label
-              key={product.id}
-              className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
-            >
-              <div className="flex flex-col">
-                <span className="font-medium text-slate-900">{product.name}</span>
-                <span className="text-xs text-slate-500">
-                  {product.brand} • {typeLabels[product.type]}
-                </span>
-              </div>
-              <input
-                type="checkbox"
-                checked={selectedProductIds.includes(product.id)}
-                disabled={disabled}
-                onChange={() => toggleProductSelection(product.id)}
-                className="h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500 disabled:opacity-40"
-              />
-            </label>
-          ))}
+          {filteredSelection.map(({ product, disabled }) => {
+            const isSelected = selectedProductIds.includes(product.id);
+            const labelClasses = [
+              'flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm text-slate-700 transition',
+              isSelected ? 'border-primary-300 bg-primary-50/70' : 'border-slate-200 bg-white',
+              disabled ? 'opacity-60' : 'hover:border-primary-200 hover:shadow-sm',
+            ]
+              .filter(Boolean)
+              .join(' ');
+
+            return (
+              <label key={product.id} className={labelClasses}>
+                <div className="flex items-center gap-3">
+                  <ProductImage
+                    imageUrl={product.imageUrl}
+                    alt={product.imageAlt ?? product.name}
+                    className="h-12 w-12 flex-shrink-0 rounded-lg"
+                    fallbackLabel={`${product.brand} ${product.name}`}
+                  />
+                  <div className="flex flex-col">
+                    <span className="font-medium text-slate-900">{product.name}</span>
+                    <span className="text-xs text-slate-500">
+                      {product.brand} • {typeLabels[product.type]}
+                    </span>
+                  </div>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  disabled={disabled}
+                  onChange={() => toggleProductSelection(product.id)}
+                  className="h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500 disabled:opacity-40"
+                />
+              </label>
+            );
+          })}
           {!isLoading && filteredSelection.length === 0 && (
             <p className="text-sm text-slate-500">Aucun produit ne correspond aux filtres.</p>
           )}

--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+type ProductImageProps = {
+  imageUrl?: string | null;
+  alt: string;
+  className?: string;
+  fallbackIcon?: ReactNode;
+  fallbackLabel?: string;
+};
+
+const baseContainerClasses = 'relative overflow-hidden bg-slate-100';
+const fallbackClasses = 'text-lg font-semibold uppercase tracking-wide text-white';
+
+const fallbackGradients = [
+  'from-primary-500 via-primary-500/95 to-primary-600',
+  'from-emerald-500 via-emerald-500/95 to-emerald-600',
+  'from-indigo-500 via-indigo-500/95 to-indigo-600',
+  'from-amber-500 via-amber-500/95 to-amber-600',
+  'from-rose-500 via-rose-500/95 to-rose-600',
+  'from-sky-500 via-sky-500/95 to-sky-600',
+];
+
+const hashString = (value: string) => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return hash;
+};
+
+const getInitials = (label: string) => {
+  const words = label
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (words.length === 0) {
+    return '??';
+  }
+
+  if (words.length === 1) {
+    return words[0]!.slice(0, 2).toUpperCase();
+  }
+
+  return (words[0]![0]! + words[1]![0]!).toUpperCase();
+};
+
+export function ProductImage({
+  imageUrl,
+  alt,
+  className = '',
+  fallbackIcon,
+  fallbackLabel,
+}: ProductImageProps) {
+  const [hasError, setHasError] = useState(false);
+
+  const containerClasses = useMemo(
+    () =>
+      [baseContainerClasses, className]
+        .filter(Boolean)
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .trim(),
+    [className],
+  );
+
+  const labelForFallback = fallbackLabel?.trim() || alt;
+
+  const gradientClass = useMemo(() => {
+    const gradientIndex = Math.abs(hashString(labelForFallback)) % fallbackGradients.length;
+    return fallbackGradients[gradientIndex] ?? fallbackGradients[0]!;
+  }, [labelForFallback]);
+
+  const shouldShowImage = Boolean(imageUrl && imageUrl.length > 0 && !hasError);
+
+  if (shouldShowImage) {
+    return (
+      <div className={containerClasses}>
+        <img
+          src={imageUrl as string}
+          alt={alt}
+          className="h-full w-full object-cover object-center"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={() => setHasError(true)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={containerClasses}>
+      <div
+        className={`flex h-full w-full items-center justify-center bg-gradient-to-br ${gradientClass}`}
+        aria-hidden
+      >
+        {fallbackIcon ? (
+          <span className="text-2xl text-white/90">{fallbackIcon}</span>
+        ) : (
+          <span className={fallbackClasses}>{getInitials(labelForFallback)}</span>
+        )}
+      </div>
+      <span className="sr-only">{alt}</span>
+    </div>
+  );
+}

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -5,6 +5,8 @@ export interface Product {
   name: string;
   brand: string;
   type: ProductType;
+  imageUrl?: string;
+  imageAlt?: string;
   price: number; // €
   originalPrice: number; // €
   discountRate: number; // 0-1
@@ -25,6 +27,9 @@ export const products: Product[] = [
     name: 'Iso Elite Vanilla',
     brand: 'NutriFuel',
     type: 'whey',
+    imageUrl:
+      'https://images.unsplash.com/photo-1586380837285-307d1fdfa4b4?auto=format&fit=crop&w=600&q=80',
+    imageAlt: 'Sachet de whey protéine Iso Elite saveur vanille',
     price: 39.9,
     originalPrice: 49.9,
     discountRate: 0.2,
@@ -42,6 +47,9 @@ export const products: Product[] = [
     name: 'Power Whey Choco',
     brand: 'PureForce',
     type: 'whey',
+    imageUrl:
+      'https://images.unsplash.com/photo-1547514701-42782101795d?auto=format&fit=crop&w=600&q=80',
+    imageAlt: 'Pot de whey chocolat Power Whey',
     price: 54.9,
     originalPrice: 64.9,
     discountRate: 0.154,
@@ -59,6 +67,9 @@ export const products: Product[] = [
     name: 'Grass-Fed Strawberry',
     brand: 'Alpine Nutrition',
     type: 'whey',
+    imageUrl:
+      'https://images.unsplash.com/photo-1586401100295-7a8096fd2315?auto=format&fit=crop&w=600&q=80',
+    imageAlt: 'Sachet de whey Grass-Fed saveur fraise',
     price: 44.5,
     originalPrice: 44.5,
     discountRate: 0,
@@ -76,6 +87,9 @@ export const products: Product[] = [
     name: 'Creapure Performance',
     brand: 'PureForce',
     type: 'creatine',
+    imageUrl:
+      'https://images.unsplash.com/photo-1585386959984-a4155223f96d?auto=format&fit=crop&w=600&q=80',
+    imageAlt: 'Boîte de créatine Creapure Performance',
     price: 24.9,
     originalPrice: 29.9,
     discountRate: 0.167,
@@ -94,6 +108,9 @@ export const products: Product[] = [
     name: 'Micronized Creatine',
     brand: 'NutriFuel',
     type: 'creatine',
+    imageUrl:
+      'https://images.unsplash.com/photo-1600180758890-6f05512d4d6c?auto=format&fit=crop&w=600&q=80',
+    imageAlt: 'Pot de poudre de créatine micronisée',
     price: 18.5,
     originalPrice: 18.5,
     discountRate: 0,
@@ -112,6 +129,9 @@ export const products: Product[] = [
     name: 'Vegan Whey Mix',
     brand: 'GreenLab',
     type: 'whey',
+    imageUrl:
+      'https://images.unsplash.com/photo-1524592094714-0f0654e20314?auto=format&fit=crop&w=600&q=80',
+    imageAlt: 'Shaker de whey végétale Vegan Whey Mix',
     price: 32.0,
     originalPrice: 36.0,
     discountRate: 0.111,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "types": ["node"],
     "module": "ESNext"
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
## Summary
- add gradient-based fallbacks and error handling to product imagery so thumbnails always render
- surface selected products as compact summary cards and restyle the comparison matrix for better readability
- wire the new image fallback labelling through highlighted deals and filter sidebar entries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3cff2e3d48325b176d9d677a7ea4c