### PR TITLE
Improve price alerts UX and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,706 +1,78 @@
-# 🏗️ Whey-Comparator - Architecture & Feuille de Route
+# 🧬 Whey Comparator
 
-## 📋 Vue d'Ensemble du Projet
+Application web construite avec **React 18 + Vite** pour comparer rapidement les compléments alimentaires (whey, créatine, etc.) et suivre leurs meilleures offres comme sur idealo.
 
-**Whey-Comparator** est une application web React/Vite permettant aux utilisateurs de comparer les prix et caractéristiques des suppléments alimentaires (protéines, créatine, etc.) à travers plusieurs plateformes e-commerce.
+## 🚀 Fonctionnalités principales
 
----
+- **Catalogue interactif** : liste fictive de whey et créatines exposée via React Query avec un délai simulé pour représenter un appel API réel.
+- **Filtres dynamiques** : filtrage par marque, type de produit et fourchette de prix avec calcul automatique des bornes.
+- **Comparateur de 2 à 4 produits** : tableau responsive affichant prix, remises, nutrition et liens externes.
+- **KPI instantanés** : calcul du prix moyen et du meilleur rapport qualité/prix basé sur les protéines par 100 g.
+- **Alertes prix** : formulaire avec validation côté client et gestion d'état (Zustand) pour simuler l'inscription à une notification e-mail.
 
-## ⚙️ Variables d'Environnement
-
-### Backend (FastAPI – `main.py`)
-
-- `SERPAPI_KEY` : clé API SerpAPI utilisée pour interroger Google Shopping.
-- `SCRAPER_BASE_URL` : URL de base du service scraper FastAPI (`services/scraper`) exposant `/products` et `/products/{id}/offers`.
-- `API_BASE_URL` *(optionnel)* : URL publique de l'API principale (utile pour les appels côté serveur du frontend).
-
-### Frontend (Next.js – `frontend/`)
-
-- `NEXT_PUBLIC_API_BASE_URL` : URL publique utilisée dans le navigateur pour atteindre l'API FastAPI.
-- `API_BASE_URL` *(optionnel)* : fallback côté serveur (App Router) si `NEXT_PUBLIC_API_BASE_URL` n'est pas défini.
-
-Toutes les requêtes front passent par `frontend/src/lib/apiClient.ts` qui injecte automatiquement ces URLs et gère la sérialisation JSON.
-
----
-
-## 🔄 Flux de Données Temps Réel
-
-1. **Collecte** : le service scraper (`services/scraper`) agrège en continu les offres Amazon/MyProtein/Google Shopping et les persiste (PostgreSQL).
-2. **Enrichissement à la demande** : `main.py` combine ces données persistées avec les résultats temps réel SerpAPI via les endpoints `/compare`, `/products`, `/products/{id}/offers` et `/comparison`.
-3. **Diffusion** : le frontend consomme ces endpoints via le client API partagé, met en cache côté React et affiche les meilleures offres avec recalcul du « best price ».
-4. **Pages dédiées** :
-   - `/products` liste le catalogue issu du scraper.
-   - `/products/{id}` fusionne offres persistées et SerpAPI pour un produit.
-   - `/comparison` compare plusieurs IDs (query `ids=1,2,3`).
-   - `/comparateur` déclenche des recherches dynamiques sur `/compare` à partir d’un mot-clé.
-
-Cette chaîne permet de déclencher des comparaisons quasi temps réel tout en capitalisant sur l'historique du scraper.
-
----
-
-
-## 🎯 Architecture Globale
-
-### Stack Technique Recommandée
-
-#### **Frontend**
-- **Framework**: React 18+ avec Vite
-- **Routing**: React Router v6
-- **State Management**: 
-  - React Context API (état global léger)
-  - TanStack Query (React Query) pour le cache et les requêtes API
-- **Styling**: 
-  - Tailwind CSS (déjà configuré avec Vite)
-  - shadcn/ui pour les composants UI
-- **Graphiques**: Recharts pour les comparaisons de prix
-- **Formulaires**: React Hook Form + Zod pour la validation
-
-#### **Backend/API Layer**
-- **Option 1 (Recommandée)**: Backend Node.js séparé
-  - Express.js ou Fastify
-  - API RESTful ou GraphQL
-  - Base de données: PostgreSQL (produits) + Redis (cache)
-  
-- **Option 2**: Backend-as-a-Service
-  - Supabase (PostgreSQL + Auth + Storage)
-  - Vercel Edge Functions pour le scraping
-
-#### **Data Collection (Scraping)**
-- **Node.js** avec:
-  - Puppeteer/Playwright (scraping JavaScript)
-  - Cheerio (parsing HTML)
-  - Axios (requêtes HTTP simples)
-- **Cron Jobs** pour mises à jour automatiques
-- **Queue System**: Bull/BullMQ pour gérer les tâches de scraping
-
----
-
-## 🗂️ Structure de Projet Recommandée
+## 🧱 Architecture du projet
 
 ```
 whey-comparator/
-├── frontend/                    # Application React
-│   ├── public/
-│   ├── src/
-│   │   ├── components/
-│   │   │   ├── ui/             # Composants shadcn/ui
-│   │   │   ├── products/       # Composants liés aux produits
-│   │   │   ├── comparison/     # Composants de comparaison
-│   │   │   └── layout/         # Layout, Header, Footer
-│   │   ├── pages/
-│   │   │   ├── Home.jsx
-│   │   │   ├── ProductList.jsx
-│   │   │   ├── ProductDetail.jsx
-│   │   │   ├── Comparison.jsx
-│   │   │   └── About.jsx
-│   │   ├── hooks/              # Custom hooks
-│   │   ├── services/           # API calls
-│   │   ├── utils/              # Fonctions utilitaires
-│   │   ├── contexts/           # React contexts
-│   │   ├── types/              # TypeScript types
-│   │   └── App.jsx
-│   ├── package.json
-│   └── vite.config.js
-│
-├── backend/                     # API Backend
-│   ├── src/
-│   │   ├── controllers/        # Logique métier
-│   │   ├── models/             # Modèles de données
-│   │   ├── routes/             # Routes API
-│   │   ├── services/           # Services (scraping, etc.)
-│   │   ├── middleware/         # Middlewares Express
-│   │   ├── config/             # Configuration
-│   │   └── server.js
-│   ├── package.json
-│   └── .env
-│
-├── scrapers/                    # Modules de scraping
-│   ├── src/
-│   │   ├── scrapers/
-│   │   │   ├── myprotein.js
-│   │   │   ├── prozis.js
-│   │   │   ├── amazon.js
-│   │   │   └── base-scraper.js
-│   │   ├── utils/
-│   │   ├── queue/              # Bull queue configuration
-│   │   └── index.js
-│   └── package.json
-│
-└── shared/                      # Code partagé
-    ├── types/                   # Types TypeScript partagés
-    └── constants/               # Constantes partagées
+├── src/
+│   ├── components/        # UI modulaire (filtres, tableau comparatif, KPI, formulaires)
+│   ├── data/              # Catalogue de produits statique (mock)
+│   ├── hooks/             # Hooks React Query pour la récupération des données
+│   ├── store/             # Stores Zustand (sélection produits, alertes prix)
+│   └── App.tsx            # Composition de la page principale
+├── index.html             # Point d'entrée Vite
+├── package.json           # Scripts npm et dépendances
+└── vite.config.ts         # Configuration Vite + React
 ```
 
----
+## 🔧 Prérequis
 
-## 🗄️ Modèle de Données
+- Node.js 18 ou version supérieure
+- npm 9+ (ou pnpm/yarn si vous adaptez les scripts)
 
-### **Product**
-```javascript
-{
-  id: string,
-  name: string,
-  brand: string,
-  category: 'whey' | 'casein' | 'creatine' | 'bcaa' | 'other',
-  type: string, // 'isolate', 'concentrate', 'blend'
-  flavor: string,
-  size: number, // en grammes
-  servingSize: number,
-  servingsPerContainer: number,
-  nutritionFacts: {
-    proteinPerServing: number,
-    caloriesPerServing: number,
-    fatPerServing: number,
-    carbsPerServing: number,
-    sugarPerServing: number
-  },
-  imageUrl: string,
-  createdAt: timestamp,
-  updatedAt: timestamp
-}
-```
-
-### **Price**
-```javascript
-{
-  id: string,
-  productId: string,
-  platform: 'myprotein' | 'prozis' | 'amazon' | 'bodybuilding',
-  price: number,
-  currency: 'EUR' | 'USD',
-  url: string,
-  inStock: boolean,
-  lastChecked: timestamp,
-  priceHistory: [
-    {
-      price: number,
-      date: timestamp
-    }
-  ]
-}
-```
-
-### **User** (optionnel, phase 2)
-```javascript
-{
-  id: string,
-  email: string,
-  favorites: [productId],
-  priceAlerts: [
-    {
-      productId: string,
-      platform: string,
-      targetPrice: number
-    }
-  ]
-}
-```
-
----
-
-## 🚀 Feuille de Route (Roadmap)
-
-### **Phase 1: Foundation (Semaines 1-2)**
-
-#### Sprint 1.1 - Setup & Infrastructure
-- [ ] Initialiser la structure backend (Express + PostgreSQL)
-- [ ] Configurer Prisma/TypeORM pour l'ORM
-- [ ] Créer les modèles de base de données
-- [ ] Setup migrations
-- [ ] Configurer les variables d'environnement
-- [ ] Créer un Docker Compose pour dev (PostgreSQL + Redis)
-
-#### Sprint 1.2 - API de Base
-- [ ] Créer les routes CRUD pour Products
-- [ ] Créer les routes CRUD pour Prices
-- [ ] Implémenter la validation avec Zod
-- [ ] Ajouter la documentation API (Swagger/OpenAPI)
-- [ ] Créer des seeds de données pour le développement
-
-#### Sprint 1.3 - Frontend Foundation
-- [ ] Installer et configurer React Router
-- [ ] Installer TanStack Query
-- [ ] Configurer les services API (axios)
-- [ ] Créer le layout principal (Header, Footer, Navigation)
-- [ ] Implémenter les pages de base (Home, ProductList)
-
----
-
-### **Phase 2: Data Collection (Semaines 3-5)**
-
-#### Sprint 2.1 - Infrastructure de Scraping
-- [ ] Créer la classe `BaseScraper` abstraite
-- [ ] Implémenter la gestion des proxies (optionnel)
-- [ ] Configurer Puppeteer avec pool de navigateurs
-- [ ] Créer un système de retry avec exponential backoff
-- [ ] Implémenter le logging (Winston)
-
-#### Sprint 2.2 - Scrapers Individuels
-- [ ] **MyProtein Scraper**
-  - Parser les pages produits
-  - Extraire prix, images, nutritions
-  - Gérer la pagination
-- [ ] **Prozis Scraper**
-  - Même approche
-- [ ] **Amazon Scraper**
-  - Attention aux détections anti-bot
-  - Utiliser l'API Product Advertising si possible
-
-#### Sprint 2.3 - Queue & Automation
-- [ ] Configurer Bull/BullMQ
-- [ ] Créer les jobs de scraping
-- [ ] Implémenter les cron jobs (mise à jour quotidienne)
-- [ ] Dashboard Bull Board pour monitoring
-- [ ] Système d'alertes en cas d'échec
-
-#### Sprint 2.4 - Data Matching
-- [ ] Algorithme de matching de produits similaires
-  - Comparaison de noms (fuzzy matching)
-  - Vérification de marque, taille, saveur
-- [ ] Système de normalisation des données
-- [ ] Détection de doublons
-
----
-
-### **Phase 3: Core Features (Semaines 6-8)**
-
-#### Sprint 3.1 - Product Display
-- [ ] Page liste des produits avec filtres
-  - Filtres: catégorie, marque, type, prix
-  - Tri: prix, popularité, protéines/€
-- [ ] Card produit avec infos essentielles
-- [ ] Système de pagination ou infinite scroll
-- [ ] Search bar avec autocomplétion
-
-#### Sprint 3.2 - Product Detail Page
-- [ ] Vue détaillée d'un produit
-- [ ] Tableau comparatif des prix par plateforme
-- [ ] Graphique d'historique des prix (Recharts)
-- [ ] Informations nutritionnelles détaillées
-- [ ] Bouton "Acheter" vers les plateformes
-
-#### Sprint 3.3 - Comparison Feature
-- [ ] Système de sélection multi-produits
-- [ ] Page de comparaison côte à côte
-- [ ] Tableau comparatif (prix, nutrition, ratio protéines/€)
-- [ ] Export en PDF (optionnel)
-- [ ] Partage de comparaison via URL
-
-#### Sprint 3.4 - Price Intelligence
-- [ ] Calcul du "meilleur rapport qualité/prix"
-  - Prix par kg de protéines
-  - Score basé sur nutrition + prix
-- [ ] Badge "Meilleure offre" sur les cards
-- [ ] Alertes de baisse de prix (email)
-
----
-
-### **Phase 4: UX Enhancement (Semaines 9-10)**
-
-#### Sprint 4.1 - Performance
-- [ ] Implémenter le cache avec TanStack Query
-- [ ] Lazy loading des images
-- [ ] Code splitting par route
-- [ ] Optimisation bundle size
-- [ ] Service Worker pour offline (optionnel)
-
-#### Sprint 4.2 - User Experience
-- [ ] Dark mode
-- [ ] Animations et transitions fluides
-- [ ] États de chargement (skeletons)
-- [ ] Gestion des erreurs utilisateur
-- [ ] Toast notifications
-
-#### Sprint 4.3 - Mobile Optimization
-- [ ] Design responsive complet
-- [ ] Touch gestures pour la comparaison
-- [ ] Menu mobile optimisé
-- [ ] PWA capabilities
-
----
-
-### **Phase 5: Advanced Features (Semaines 11-12)**
-
-#### Sprint 5.1 - User Accounts (optionnel)
-- [ ] Authentification (Supabase Auth ou JWT)
-- [ ] Profil utilisateur
-- [ ] Liste de favoris
-- [ ] Historique de recherches
-
-#### Sprint 5.2 - Price Alerts
-- [ ] Système d'alertes email
-- [ ] Configuration des seuils de prix
-- [ ] Notifications push (optionnel)
-
-#### Sprint 5.3 - Analytics & SEO
-- [ ] Intégration Google Analytics
-- [ ] Meta tags optimisés
-- [ ] Sitemap dynamique
-- [ ] Structured data (JSON-LD)
-
----
-
-## 🔧 Défis Techniques & Solutions
-
-### **1. Scraping Challenges**
-
-#### **Anti-Bot Detection**
-- **Problème**: Sites protégés contre le scraping
-- **Solutions**:
-  - User-Agent rotation
-  - Proxies résidentiels (BrightData, Oxylabs)
-  - Playwright avec empreintes browser réalistes
-  - Rate limiting intelligent
-  - Scraping pendant heures creuses
-
-#### **Structure HTML Variable**
-- **Problème**: Sites changent leur HTML
-- **Solutions**:
-  - Sélecteurs CSS/XPath multiples (fallbacks)
-  - Tests automatisés des scrapers
-  - Système d'alertes si scraping échoue
-  - Documentation des selectors dans le code
-
-#### **JavaScript Rendering**
-- **Problème**: Contenu chargé en JavaScript
-- **Solutions**:
-  - Puppeteer/Playwright (full browser)
-  - Attente des éléments avec `waitForSelector`
-  - Inspection des requêtes réseau (API directe)
-
-### **2. Data Matching**
-
-**Algorithme de Matching Recommandé**:
-```javascript
-function matchProducts(product1, product2) {
-  const similarity = {
-    brand: product1.brand === product2.brand ? 1 : 0,
-    name: stringSimilarity(product1.name, product2.name),
-    size: Math.abs(product1.size - product2.size) < 100 ? 1 : 0,
-    flavor: product1.flavor === product2.flavor ? 1 : 0
-  };
-  
-  const score = 
-    similarity.brand * 0.3 +
-    similarity.name * 0.4 +
-    similarity.size * 0.2 +
-    similarity.flavor * 0.1;
-  
-  return score > 0.7; // Threshold
-}
-```
-
-### **3. Performance**
-
-- **Cache Redis**: 
-  - Cache des prix pendant 1h
-  - Cache des listes de produits pendant 24h
-- **CDN**: Cloudflare pour images et assets
-- **Database Indexing**: 
-  - Index sur `brand`, `category`, `price`
-- **Pagination API**: Limite 20-50 produits par page
-
----
-
-## 📦 Code Samples
-
-### **Frontend: Product Card Component**
-
-```jsx
-// src/components/products/ProductCard.jsx
-import { Link } from 'react-router-dom';
-import { Card, CardContent, CardFooter } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-
-export function ProductCard({ product, prices }) {
-  const lowestPrice = Math.min(...prices.map(p => p.price));
-  const bestPlatform = prices.find(p => p.price === lowestPrice);
-  
-  const pricePerKgProtein = (
-    lowestPrice / 
-    (product.nutritionFacts.proteinPerServing * product.servingsPerContainer / 1000)
-  ).toFixed(2);
-
-  return (
-    <Card className="hover:shadow-lg transition-shadow">
-      <CardContent className="p-4">
-        <img 
-          src={product.imageUrl} 
-          alt={product.name}
-          className="w-full h-48 object-cover rounded-md"
-        />
-        <h3 className="font-semibold mt-2 line-clamp-2">
-          {product.name}
-        </h3>
-        <p className="text-sm text-gray-600">{product.brand}</p>
-        
-        <div className="flex gap-2 mt-2">
-          <Badge variant="secondary">{product.type}</Badge>
-          <Badge variant="outline">{product.size}g</Badge>
-        </div>
-      </CardContent>
-      
-      <CardFooter className="flex justify-between items-center">
-        <div>
-          <p className="text-2xl font-bold text-green-600">
-            {lowestPrice.toFixed(2)}€
-          </p>
-          <p className="text-xs text-gray-500">
-            {pricePerKgProtein}€/kg de protéines
-          </p>
-        </div>
-        
-        <Link 
-          to={`/products/${product.id}`}
-          className="btn-primary"
-        >
-          Comparer
-        </Link>
-      </CardFooter>
-    </Card>
-  );
-}
-```
-
-### **Backend: Scraper Base Class**
-
-```javascript
-// scrapers/src/scrapers/base-scraper.js
-import puppeteer from 'puppeteer';
-import { logger } from '../utils/logger.js';
-
-export class BaseScraper {
-  constructor(platform) {
-    this.platform = platform;
-    this.browser = null;
-    this.maxRetries = 3;
-  }
-
-  async init() {
-    this.browser = await puppeteer.launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
-    });
-  }
-
-  async close() {
-    if (this.browser) {
-      await this.browser.close();
-    }
-  }
-
-  async scrapeWithRetry(url, scrapeFn, retries = this.maxRetries) {
-    try {
-      const page = await this.browser.newPage();
-      await page.setUserAgent('Mozilla/5.0...');
-      
-      await page.goto(url, { waitUntil: 'networkidle2' });
-      const result = await scrapeFn(page);
-      
-      await page.close();
-      return result;
-    } catch (error) {
-      logger.error(`Scraping failed for ${url}`, error);
-      
-      if (retries > 0) {
-        logger.info(`Retrying... (${retries} attempts left)`);
-        await this.sleep(2000);
-        return this.scrapeWithRetry(url, scrapeFn, retries - 1);
-      }
-      
-      throw error;
-    }
-  }
-
-  sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  // À implémenter par les scrapers enfants
-  async scrapeProduct(url) {
-    throw new Error('scrapeProduct must be implemented');
-  }
-}
-```
-
-### **Backend: MyProtein Scraper**
-
-```javascript
-// scrapers/src/scrapers/myprotein.js
-import { BaseScraper } from './base-scraper.js';
-
-export class MyProteinScraper extends BaseScraper {
-  constructor() {
-    super('myprotein');
-    this.baseUrl = 'https://www.myprotein.fr';
-  }
-
-  async scrapeProduct(url) {
-    return this.scrapeWithRetry(url, async (page) => {
-      // Attendre le chargement du prix
-      await page.waitForSelector('.productPrice_price');
-
-      const product = await page.evaluate(() => {
-        const name = document.querySelector('h1.productName')?.textContent.trim();
-        const price = document.querySelector('.productPrice_price')?.textContent
-          .replace('€', '').replace(',', '.').trim();
-        const image = document.querySelector('.athenaProductImageCarousel_image img')?.src;
-        
-        // Extraire les infos nutritionnelles
-        const nutritionTable = document.querySelector('.athenaProductNutrition_table');
-        const proteinRow = Array.from(nutritionTable?.querySelectorAll('tr') || [])
-          .find(row => row.textContent.includes('Protéines'));
-        const protein = proteinRow?.querySelector('td')?.textContent.trim();
-
-        return {
-          name,
-          price: parseFloat(price),
-          imageUrl: image,
-          proteinPerServing: parseFloat(protein)
-        };
-      });
-
-      return product;
-    });
-  }
-
-  async scrapeCategory(categoryUrl) {
-    const products = [];
-    let page = 1;
-    let hasMore = true;
-
-    while (hasMore) {
-      const url = `${categoryUrl}?page=${page}`;
-      const pageProducts = await this.scrapeProductList(url);
-      
-      products.push(...pageProducts);
-      hasMore = pageProducts.length > 0;
-      page++;
-    }
-
-    return products;
-  }
-
-  async scrapeProductList(url) {
-    return this.scrapeWithRetry(url, async (page) => {
-      await page.waitForSelector('.productListProducts_product');
-
-      const products = await page.evaluate(() => {
-        const items = document.querySelectorAll('.productListProducts_product');
-        return Array.from(items).map(item => ({
-          name: item.querySelector('.productCard_productName')?.textContent.trim(),
-          url: item.querySelector('a')?.href,
-          price: parseFloat(
-            item.querySelector('.productPrice_price')?.textContent
-              .replace('€', '').replace(',', '.').trim()
-          )
-        }));
-      });
-
-      return products;
-    });
-  }
-}
-```
-
----
-
-## 🧪 Testing Strategy
-
-### **Frontend Tests**
-- **Unit**: Components avec Vitest + React Testing Library
-- **Integration**: User flows avec Playwright
-- **E2E**: Scénarios critiques (recherche → comparaison → achat)
-
-### **Backend Tests**
-- **Unit**: Services et utilities avec Jest
-- **Integration**: Routes API avec Supertest
-- **Scrapers**: Mocked responses + tests sur des pages HTML statiques
-
----
-
-## 🚢 Deployment
-
-### **Recommandation**
-
-#### **Frontend**
-- **Vercel** ou **Netlify** (déploiement automatique depuis GitHub)
-- Build optimisé avec Vite
-- Variables d'env pour l'API URL
-
-#### **Backend**
-- **Railway** ou **Render** (PostgreSQL inclus)
-- Cron jobs pour scraping
-- Redis pour cache
-
-#### **Alternative Cloud**
-- **AWS**: EC2 + RDS + ElastiCache + EventBridge (cron)
-- **Google Cloud**: Cloud Run + Cloud SQL + Memorystore
-
----
-
-## 📊 Métriques de Succès
-
-- **Performance**: Temps de chargement < 2s
-- **Data Freshness**: Prix mis à jour toutes les 24h
-- **Coverage**: Au moins 3 plateformes scrapées
-- **Accuracy**: 95%+ de matching correct entre produits
-- **Uptime**: 99% pour l'API
-
----
-
-## 🔒 Considérations Légales
-
-⚠️ **Important**: Le scraping peut violer les CGU des sites. Considérer:
-- APIs officielles quand disponibles (Amazon Product API)
-- Partenariats d'affiliation
-- Rate limiting respectueux
-- Mention légale sur l'origine des données
-
----
-
-## 📚 Resources & Tools
-
-### **Libraries Clés**
-- **Frontend**: React Router, TanStack Query, Recharts, React Hook Form
-- **Backend**: Express, Prisma, Bull, Puppeteer
-- **Dev**: Vitest, Playwright, ESLint, Prettier
-
-### **Services Externes**
-- **Scraping Proxies**: BrightData, ScraperAPI
-- **Email**: SendGrid, Resend
-- **Monitoring**: Sentry, LogRocket
-
----
-
-## 🎯 Quick Start Commands
+## ▶️ Démarrer le projet
 
 ```bash
-# Backend setup
-cd backend
-npm install
-cp .env.example .env
-npx prisma migrate dev
-npm run seed
-npm run dev
-
-# Frontend setup
-cd frontend
 npm install
 npm run dev
-
-# Scrapers
-cd scrapers
-npm install
-npm run scrape:myprotein
 ```
+
+Le serveur Vite démarre généralement sur [http://localhost:5173](http://localhost:5173). Le mode `dev` recharge automatiquement la page.
+
+### Autres scripts utiles
+
+| Commande         | Description                                         |
+|------------------|-----------------------------------------------------|
+| `npm run build`  | Vérifie les types TypeScript et génère le bundle.   |
+| `npm run preview`| Sert la version buildée.                            |
+| `npm run lint`   | Analyse le code avec ESLint (règles React + TS).    |
+
+## 🌐 Variables d'environnement
+
+Le store des alertes prix peut envoyer les inscriptions vers un service externe.
+Définissez l'URL dans un fichier `.env` à la racine :
+
+```bash
+VITE_SERPAI_PRICE_ALERT_URL=https://votre-api.exemple.com/alerts
+```
+
+Si la variable n'est pas définie, une simulation locale s'exécute (latence + erreurs aléatoires) pour faciliter le développement.
+
+## 🧠 Points clés de l'implémentation
+
+- **React Query** gère le cache produit (`src/hooks/useProducts.ts`) avec un temps de conservation de 5 minutes.
+- **Zustand** gère :
+  - la sélection de 2 à 4 produits (`src/store/productSelectionStore.ts`),
+  - le formulaire d'alertes prix (`src/store/priceAlertStore.ts`).
+- **Tailwind CSS** fournit les styles utilitaires utilisés dans toute l'application.
+- Le composant `PriceAlertsSection` encapsule le formulaire, la mise en page marketing et les états de chargement.
+
+## 🔭 Prochaines évolutions envisagées
+
+- Remplacer les données statiques par une API FastAPI/Node et un scraper temps réel.
+- Ajouter l'authentification utilisateur pour sauvegarder favoris et alertes.
+- Intégrer de vrais graphiques d'historique des prix (Recharts est déjà installé).
 
 ---
 
-**Prochaines étapes recommandées:**
-1. Setup du backend avec Prisma + PostgreSQL
-2. Création du premier scraper (MyProtein)
-3. API endpoint `/products` avec filtres
-4. Interface produit de base avec React Query
-
-Bonne chance avec Whey-Comparator! 🚀
+💡 Ce dépôt sert de base front-end : structure, expérience utilisateur et gestion d'état sont prêtes pour une intégration ultérieure avec des services back-end et des données en temps réel.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,20 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
-
 import { KpiSummaryBar } from './components/KpiSummaryBar';
-import { PriceAlertForm } from './components/PriceAlertForm';
 import { ProductFiltersSidebar } from './components/ProductFiltersSidebar';
 
 import { ProductComparisonTable } from './components/ProductComparisonTable';
 
 import { HighlightedDealsSection } from './components/HighlightedDealsSection';
+import { PriceAlertsSection } from './components/PriceAlertsSection';
 import { highlightedDeals } from './data/products';
 import { useProducts } from './hooks/useProducts';
-import { selectFilters, selectSelectedProductIds, useProductSelectionStore } from './store/productSelectionStore';
+import {
+  selectFilters,
+  selectSelectedProductIds,
+  useProductSelectionStore,
+} from './store/productSelectionStore';
 import { usePriceAlertStore } from './store/priceAlertStore';
 
 
@@ -19,7 +22,15 @@ export default function App() {
   const { data: products = [], isLoading } = useProducts();
   const filters = useProductSelectionStore(useShallow(selectFilters));
   const selectedProductIds = useProductSelectionStore(selectSelectedProductIds);
+  const setSelectedProductIds = useProductSelectionStore((state) => state.setSelectedProductIds);
   const activeAlertCount = usePriceAlertStore((state) => state.alerts.length);
+
+  useEffect(() => {
+    if (!isLoading && products.length > 0 && selectedProductIds.length === 0) {
+      const defaultSelection = products.slice(0, Math.min(products.length, 2)).map((product) => product.id);
+      setSelectedProductIds(defaultSelection);
+    }
+  }, [isLoading, products, selectedProductIds.length, setSelectedProductIds]);
 
   const filteredProducts = useMemo(() => {
     return products.filter((product) => {
@@ -81,7 +92,7 @@ export default function App() {
           <ProductComparisonTable products={selectedProducts} isLoading={isLoading} />
         </div>
 
-
+        <PriceAlertsSection products={products} isLoading={isLoading} />
       </div>
     </div>
   );

--- a/src/components/PriceAlertForm.tsx
+++ b/src/components/PriceAlertForm.tsx
@@ -6,6 +6,7 @@ import { usePriceAlertStore } from '../store/priceAlertStore';
 
 interface PriceAlertFormProps {
   products: Product[];
+  className?: string;
 }
 
 interface FormErrors {
@@ -16,7 +17,7 @@ interface FormErrors {
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export function PriceAlertForm({ products }: PriceAlertFormProps) {
+export function PriceAlertForm({ products, className }: PriceAlertFormProps) {
   const { email, productId, priceThreshold, alerts, status, message } = usePriceAlertStore(
     useShallow((state) => ({
       email: state.email,
@@ -108,7 +109,7 @@ export function PriceAlertForm({ products }: PriceAlertFormProps) {
   const isLoading = status === 'loading';
 
   return (
-    <div className="space-y-8">
+    <div className={`space-y-8 ${className ?? ''}`.trim()}>
       <form className="grid gap-4 md:grid-cols-3" onSubmit={handleSubmit}>
         <div className="md:col-span-1">
           <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="price-alert-email">

--- a/src/components/PriceAlertsSection.tsx
+++ b/src/components/PriceAlertsSection.tsx
@@ -1,55 +1,74 @@
-export function PriceAlertsSection() {
+import { useShallow } from 'zustand/react/shallow';
+
+import type { Product } from '../data/products';
+import { usePriceAlertStore } from '../store/priceAlertStore';
+import { PriceAlertForm } from './PriceAlertForm';
+
+interface PriceAlertsSectionProps {
+  products: Product[];
+  isLoading: boolean;
+}
+
+export function PriceAlertsSection({ products, isLoading }: PriceAlertsSectionProps) {
+  const { alerts, status } = usePriceAlertStore(
+    useShallow((state) => ({ alerts: state.alerts, status: state.status })),
+  );
+
+  const activeAlertLabel =
+    alerts.length === 0
+      ? 'Aucune alerte créée pour le moment.'
+      : alerts.length === 1
+        ? '1 alerte active — soyez le premier averti !'
+        : `${alerts.length} alertes actives — merci pour votre confiance !`;
+
   return (
     <section
-      id="alertes-prix"
+      id="price-alerts"
       className="relative overflow-hidden rounded-3xl border border-primary-100 bg-primary-50/60 p-8"
     >
       <div className="absolute -right-10 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-primary-200/40 blur-3xl" aria-hidden />
-      <div className="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+      <div className="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
         <div className="max-w-xl space-y-4">
           <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-600">Alertes prix</p>
-          <h2 className="text-3xl font-bold text-slate-900">Soyez averti dès qu'une whey atteint votre prix cible</h2>
+          <h2 className="text-3xl font-bold text-slate-900">
+            Soyez averti dès qu'un complément atteint votre prix idéal
+          </h2>
           <p className="text-base text-slate-600">
-            Configurez une alerte et recevez un email lorsqu'une boutique partenaire passe sous votre prix
-            idéal. Inspiré du suivi intelligent idealo, vous ne raterez plus jamais un bon plan.
+            Enregistrez une alerte et recevez un email lorsque nos partenaires franchissent votre seuil cible.
+            Chaque inscription déclenche une surveillance automatique avec accusé de réception.
           </p>
+          <ul className="space-y-2 text-sm text-slate-600">
+            <li>• Priorité aux meilleures offres whey et créatine.</li>
+            <li>• Désactivation en un clic depuis le tableau des alertes.</li>
+            <li>• {activeAlertLabel}</li>
+          </ul>
         </div>
-        <form className="w-full max-w-md space-y-4 rounded-2xl bg-white p-6 shadow-sm shadow-primary-900/10">
-          <div className="space-y-1">
-            <label htmlFor="alert-email" className="text-sm font-medium text-slate-700">
-              Adresse email
-            </label>
-            <input
-              id="alert-email"
-              type="email"
-              placeholder="vous@exemple.com"
-              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm transition focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200"
+        <div className="w-full max-w-xl">
+          {isLoading && products.length === 0 ? (
+            <div className="space-y-4 rounded-2xl bg-white p-6 shadow-sm shadow-primary-900/5">
+              <div className="h-5 w-40 animate-pulse rounded bg-slate-200" />
+              <div className="grid gap-4 md:grid-cols-3">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div key={index} className="space-y-2">
+                    <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+                    <div className="h-10 w-full animate-pulse rounded bg-slate-100" />
+                  </div>
+                ))}
+              </div>
+              <div className="h-10 w-full animate-pulse rounded-full bg-primary-100" />
+            </div>
+          ) : (
+            <PriceAlertForm
+              products={products}
+              className="rounded-2xl bg-white p-6 shadow-sm shadow-primary-900/10"
             />
-          </div>
-          <div className="space-y-1">
-            <label htmlFor="alert-target" className="text-sm font-medium text-slate-700">
-              Prix cible (€/kg)
-            </label>
-            <input
-              id="alert-target"
-              type="number"
-              min="0"
-              step="0.5"
-              placeholder="Ex : 18"
-              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm transition focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200"
-            />
-          </div>
-          <button
-            type="button"
-            className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-primary-400"
-          >
-            Créer mon alerte personnalisée
-          </button>
-          <p className="text-xs text-slate-500">
-            Nous surveillons en continu les variations de prix. Recevez un résumé complet avant que l'offre ne
-            disparaisse.
-          </p>
-        </form>
+          )}
+          {status === 'loading' ? (
+            <p className="mt-2 text-xs text-slate-500">
+              Connexion au service d'alertes en cours…
+            </p>
+          ) : null}
+        </div>
       </div>
     </section>
   );

--- a/src/store/productSelectionStore.ts
+++ b/src/store/productSelectionStore.ts
@@ -10,6 +10,7 @@ interface ProductSelectionState {
   priceBounds: Range;
   priceRange: Range;
   selectedProductIds: string[];
+  setSelectedProductIds: (productIds: string[]) => void;
   setSelectedBrands: (brands: string[]) => void;
   setSelectedTypes: (types: ProductType[]) => void;
   setPriceBounds: (bounds: Range) => void;
@@ -26,6 +27,8 @@ export const useProductSelectionStore = create<ProductSelectionState>((set) => (
   priceBounds: defaultRange,
   priceRange: defaultRange,
   selectedProductIds: [],
+  setSelectedProductIds: (productIds) =>
+    set({ selectedProductIds: productIds.slice(0, 4) }),
   setSelectedBrands: (brands) => set({ selectedBrands: brands }),
   setSelectedTypes: (types) => set({ selectedTypes: types }),
   setPriceBounds: (bounds) =>


### PR DESCRIPTION
## Summary
- rewrite the README with current project information, setup steps, and architecture hints
- auto-select default products, surface the new price alerts section, and polish the alert form layout
- extend the product selection store with a setter to support the default comparison state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4276f5bb08325989ffa8706f73afa