### PR TITLE
Fix product imagery fallback and offers layout

### DIFF
--- a/frontend/src/components/OfferTable.tsx
+++ b/frontend/src/components/OfferTable.tsx
@@ -64,102 +64,104 @@ export function OfferTable({ offers, caption }: OfferTableProps) {
 
   return (
     <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
-      <table className="w-full text-left text-sm text-gray-200">
-        {caption && (
-          <caption className="bg-white/5 px-4 py-3 text-left text-sm font-semibold text-white">
-            {caption}
-          </caption>
-        )}
-        <thead className="bg-white/5 text-xs uppercase tracking-wide text-gray-300">
-          <tr>
-            <th scope="col" className="px-4 py-3">
-              Vendeur
-            </th>
-            <th scope="col" className="px-4 py-3">
-              Prix
-            </th>
-            <th scope="col" className="px-4 py-3">
-              Livraison
-            </th>
-            <th scope="col" className="px-4 py-3">
-              Total
-            </th>
-            <th scope="col" className="px-4 py-3">
-              Stock
-            </th>
-            <th scope="col" className="px-4 py-3">
-              Source
-            </th>
-            <th scope="col" className="px-4 py-3">
-              Actions
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {offers.map((offer) => (
-            <tr
-              key={offer.id}
-              className={`border-t border-white/10 transition hover:bg-white/5 ${
-                offer.bestPrice || offer.isBestPrice ? "bg-emerald-500/10" : "bg-transparent"
-              }`}
-            >
-              <th scope="row" className="px-4 py-3 font-medium text-white">
-                <div className="flex flex-col gap-1">
-                  <span className="flex items-center gap-2">
-                    {offer.vendor}
-                    {(offer.bestPrice || offer.isBestPrice) && (
-                      <span className="inline-flex items-center rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
-                        Meilleur prix
-                      </span>
-                    )}
-                  </span>
-                  <span className="text-xs text-gray-400">{offer.title}</span>
-                </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-left text-sm text-gray-200">
+          {caption && (
+            <caption className="bg-white/5 px-4 py-3 text-left text-sm font-semibold text-white">
+              {caption}
+            </caption>
+          )}
+          <thead className="bg-white/5 text-xs uppercase tracking-wide text-gray-300">
+            <tr>
+              <th scope="col" className="px-4 py-3">
+                Vendeur
               </th>
-              <td className="px-4 py-3 text-white">
-                <div className="flex flex-col">
-                  <span className="font-semibold">{formatPrice(offer.price)}</span>
-                  {typeof offer.pricePerKg === "number" && (
-                    <span className="text-xs text-gray-400">{offer.pricePerKg.toFixed(2)} €/kg</span>
-                  )}
-                </div>
-              </td>
-              <td className="px-4 py-3 text-gray-200">{formatShipping(offer)}</td>
-              <td className="px-4 py-3 text-white">
-                <span className="font-semibold">
-                  {formatPrice(offer.totalPrice ?? offer.price)}
-                </span>
-              </td>
-              <td className="px-4 py-3 text-white">
-                {(() => {
-                  const availability = getAvailability(offer);
-                  return (
-                    <span className="inline-flex items-center gap-2" aria-label={availability.label}>
-                      <span aria-hidden>{availability.icon}</span>
-                      <span className="text-xs text-gray-300">{availability.label}</span>
-                    </span>
-                  );
-                })()}
-              </td>
-              <td className="px-4 py-3 text-gray-300">{offer.source}</td>
-              <td className="px-4 py-3">
-                {offer.link ? (
-                  <a
-                    href={offer.link}
-                    target="_blank"
-                    rel="noopener noreferrer nofollow"
-                    className="inline-flex items-center gap-2 rounded-full bg-orange-500 px-3 py-1 text-xs font-semibold text-white transition hover:bg-orange-600"
-                  >
-                    Consulter →
-                  </a>
-                ) : (
-                  <span className="text-xs text-gray-500">Lien indisponible</span>
-                )}
-              </td>
+              <th scope="col" className="px-4 py-3">
+                Prix
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Livraison
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Total
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Stock
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Source
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Actions
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {offers.map((offer) => (
+              <tr
+                key={offer.id}
+                className={`border-t border-white/10 transition hover:bg-white/5 ${
+                  offer.bestPrice || offer.isBestPrice ? "bg-emerald-500/10" : "bg-transparent"
+                }`}
+              >
+                <th scope="row" className="px-4 py-3 font-medium text-white">
+                  <div className="flex flex-col gap-1">
+                    <span className="flex items-center gap-2">
+                      {offer.vendor}
+                      {(offer.bestPrice || offer.isBestPrice) && (
+                        <span className="inline-flex items-center rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                          Meilleur prix
+                        </span>
+                      )}
+                    </span>
+                    <span className="text-xs text-gray-400">{offer.title}</span>
+                  </div>
+                </th>
+                <td className="px-4 py-3 text-white">
+                  <div className="flex flex-col">
+                    <span className="font-semibold">{formatPrice(offer.price)}</span>
+                    {typeof offer.pricePerKg === "number" && (
+                      <span className="text-xs text-gray-400">{offer.pricePerKg.toFixed(2)} €/kg</span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-gray-200">{formatShipping(offer)}</td>
+                <td className="px-4 py-3 text-white">
+                  <span className="font-semibold">
+                    {formatPrice(offer.totalPrice ?? offer.price)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-white">
+                  {(() => {
+                    const availability = getAvailability(offer);
+                    return (
+                      <span className="inline-flex items-center gap-2" aria-label={availability.label}>
+                        <span aria-hidden>{availability.icon}</span>
+                        <span className="text-xs text-gray-300">{availability.label}</span>
+                      </span>
+                    );
+                  })()}
+                </td>
+                <td className="px-4 py-3 text-gray-300">{offer.source}</td>
+                <td className="px-4 py-3">
+                  {offer.link ? (
+                    <a
+                      href={offer.link}
+                      target="_blank"
+                      rel="noopener noreferrer nofollow"
+                      className="inline-flex items-center gap-2 rounded-full bg-orange-500 px-3 py-1 text-xs font-semibold text-white transition hover:bg-orange-600"
+                    >
+                      Consulter →
+                    </a>
+                  ) : (
+                    <span className="text-xs text-gray-500">Lien indisponible</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Link from "next/link";
 
 import type { ProductSummary } from "@/types/api";
@@ -66,18 +67,21 @@ export function ProductCard({ product, href, footer }: ProductCardProps) {
     footer && <div className="mt-6 border-t border-white/10 pt-4 text-sm text-gray-300">{footer}</div>;
 
   const productImage = getProductImage(product);
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = productImage && !imageFailed;
 
   const body = (
     <div className="flex flex-1 flex-col justify-between">
       <div>
         <div className="relative mb-4 overflow-hidden rounded-xl border border-white/10 bg-white/5">
-          {productImage ? (
+          {showImage ? (
             // eslint-disable-next-line @next/next/no-img-element -- remote catalogue assets
             <img
               src={productImage.src}
               alt={productImage.alt}
               className="h-40 w-full object-cover object-center"
               loading="lazy"
+              onError={() => setImageFailed(true)}
             />
           ) : (
             <div className="flex h-40 w-full items-center justify-center bg-gradient-to-br from-slate-800/60 to-slate-900/80 text-sm text-gray-400">


### PR DESCRIPTION
## Summary
- ensure product cards gracefully fallback to a placeholder when product images fail to load
- make the selected offers table horizontally scrollable to avoid layout overflow on product pages

## Testing
- npm run lint *(fails: ESLint config next/core-web-vitals missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eb5afba48325abf7b83d599ba68c