### PR TITLE
Fix product image display on comparison view

### DIFF
--- a/frontend/src/app/comparison/page.tsx
+++ b/frontend/src/app/comparison/page.tsx
@@ -66,7 +66,7 @@ export default async function ComparisonPage({ searchParams }: ComparisonPagePro
   return (
     <div className="min-h-screen bg-[#0b1320] text-white">
       <header className="border-b border-white/10 bg-[#0d1b2a]">
-        <div className="container mx-auto flex flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
           <Link href="/" className="text-2xl font-extrabold text-orange-500">
             💪 Sport Comparator
           </Link>
@@ -81,7 +81,7 @@ export default async function ComparisonPage({ searchParams }: ComparisonPagePro
         </div>
       </header>
 
-      <main className="container mx-auto px-6 py-12">
+      <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-3xl font-bold sm:text-4xl">Comparateur multi-produits</h1>

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -76,24 +76,26 @@ export function ProductCard({ product, href, footer }: ProductCardProps) {
     <div className="flex flex-1 flex-col justify-between">
       <div>
         <div className="relative mb-4 overflow-hidden rounded-xl border border-white/10 bg-white/5">
-          {showImage ? (
-            // eslint-disable-next-line @next/next/no-img-element -- remote catalogue assets
-            <img
-              src={productImage.src}
-              alt={productImage.alt}
-              className="h-40 w-full object-cover object-center"
-              loading="lazy"
-              onError={() => setImageFailed(true)}
-            />
-          ) : (
-            <div className="flex h-40 w-full items-center justify-center bg-gradient-to-br from-slate-800/60 to-slate-900/80 text-sm text-gray-400">
-              <span className="flex items-center gap-2">
-                <span aria-hidden>📦</span>
+          <div className="flex aspect-[4/3] w-full items-center justify-center bg-gradient-to-br from-slate-900/40 via-slate-900/20 to-slate-900/60 p-4">
+            {showImage ? (
+              // eslint-disable-next-line @next/next/no-img-element -- remote catalogue assets
+              <img
+                src={productImage.src}
+                alt={productImage.alt}
+                className="h-full w-full object-contain object-center drop-shadow-sm"
+                loading="lazy"
+                onError={() => setImageFailed(true)}
+              />
+            ) : (
+              <span className="flex flex-col items-center gap-2 text-sm text-gray-400">
+                <span aria-hidden className="text-lg">
+                  📦
+                </span>
                 <span>Image indisponible</span>
               </span>
-            </div>
-          )}
-          <div className="absolute inset-x-3 bottom-3 inline-flex items-center rounded-full bg-black/60 px-3 py-1 text-xs text-orange-200">
+            )}
+          </div>
+          <div className="pointer-events-none absolute inset-x-3 bottom-3 inline-flex items-center rounded-full bg-black/60 px-3 py-1 text-xs text-orange-200 shadow-md">
             {product.brand ?? "Produit"}
           </div>
         </div>
@@ -103,36 +105,37 @@ export function ProductCard({ product, href, footer }: ProductCardProps) {
             <p className="text-sm text-gray-300">Saveur : {product.flavour}</p>
           )}
           <div className="rounded-xl bg-white/5 p-3 text-sm text-gray-100">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-wide text-gray-400">Meilleur prix</p>
-              <p className="text-lg font-semibold text-white">{formatBestPrice(product.bestPrice)}</p>
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-400">Meilleur prix</p>
+                <p className="text-lg font-semibold text-white">{formatBestPrice(product.bestPrice)}</p>
+              </div>
+              <div className="text-right text-xs text-gray-300">
+                <p>{product.bestVendor ?? "Vendeur"}</p>
+                {product.inStock !== undefined && product.inStock !== null && (
+                  <p className="mt-1 flex items-center gap-1 text-xs text-gray-200">
+                    <span aria-hidden>{product.inStock ? "✅" : "❌"}</span>
+                    <span className="sr-only">{product.inStock ? "Disponible" : "Indisponible"}</span>
+                    <span className="text-gray-300">{product.inStock ? "En stock" : "Rupture"}</span>
+                  </p>
+                )}
+              </div>
             </div>
-            <div className="text-right text-xs text-gray-300">
-              <p>{product.bestVendor ?? "Vendeur"}</p>
-              {product.inStock !== undefined && product.inStock !== null && (
-                <p className="mt-1 flex items-center gap-1 text-xs text-gray-200">
-                  <span aria-hidden>{product.inStock ? "✅" : "❌"}</span>
-                  <span className="sr-only">{product.inStock ? "Disponible" : "Indisponible"}</span>
-                  <span className="text-gray-300">{product.inStock ? "En stock" : "Rupture"}</span>
-                </p>
-              )}
-            </div>
-          </div>
-          <div className="mt-2 grid grid-cols-2 gap-3 text-xs text-gray-300">
-            <div>
-              <span className="block uppercase tracking-wide text-[11px] text-gray-500">Protéines/€</span>
-              <span className="font-semibold text-white">
-                {typeof product.proteinPerEuro === "number"
-                  ? `${product.proteinPerEuro.toFixed(2)} g`
-                  : "—"}
-              </span>
-            </div>
-            <div>
-              <span className="block uppercase tracking-wide text-[11px] text-gray-500">Note</span>
-              <span className="font-semibold text-white">
-                {typeof product.rating === "number" ? `${product.rating.toFixed(1)} ★` : "—"}
-              </span>
+            <div className="mt-2 grid grid-cols-2 gap-3 text-xs text-gray-300">
+              <div>
+                <span className="block uppercase tracking-wide text-[11px] text-gray-500">Protéines/€</span>
+                <span className="font-semibold text-white">
+                  {typeof product.proteinPerEuro === "number"
+                    ? `${product.proteinPerEuro.toFixed(2)} g`
+                    : "—"}
+                </span>
+              </div>
+              <div>
+                <span className="block uppercase tracking-wide text-[11px] text-gray-500">Note</span>
+                <span className="font-semibold text-white">
+                  {typeof product.rating === "number" ? `${product.rating.toFixed(1)} ★` : "—"}
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -154,7 +157,6 @@ export function ProductCard({ product, href, footer }: ProductCardProps) {
             </dd>
           </div>
         </dl>
-      </div>
       </div>
     </div>
   );

--- a/frontend/src/components/SiteFooter.tsx
+++ b/frontend/src/components/SiteFooter.tsx
@@ -58,7 +58,7 @@ export function SiteFooter() {
   return (
     <footer className="bg-[#0d1b2a] text-gray-300">
       <div className="border-b border-white/10">
-        <div className="container mx-auto px-6 py-12">
+        <div className="mx-auto w-full max-w-6xl px-6 py-12">
           <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-5">
             <div className="space-y-4">
               <h2 className="text-xl font-bold text-white">Sport Comparator</h2>
@@ -216,7 +216,7 @@ export function SiteFooter() {
       </div>
 
       <div className="bg-[#0b1320]">
-        <div className="container mx-auto flex flex-col gap-4 px-6 py-4 text-sm text-gray-400 md:flex-row md:items-center md:justify-between">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4 text-sm text-gray-400 md:flex-row md:items-center md:justify-between">
           <p>© {new Date().getFullYear()} Sport Comparator. Tous droits réservés.</p>
           <div className="flex items-center gap-4">
             {socialLinks.map(({ href, label, icon }) => (


### PR DESCRIPTION
## Summary
- constrain the comparison header, body, and footer to a consistent max width for better alignment
- restyle product cards to keep images centered within a fixed aspect ratio and improve the fallback state

## Testing
- Not run (npm install fails: npm error 403 when downloading dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e4f7c41100832580e25efdc83653aa