### PR TITLE
Fix awaiting route params on comparison and product pages

### DIFF
--- a/frontend/src/app/comparison/page.tsx
+++ b/frontend/src/app/comparison/page.tsx
@@ -8,7 +8,7 @@ import apiClient from "@/lib/apiClient";
 import type { ComparisonResponse, ProductListResponse, ProductSummary } from "@/types/api";
 
 interface ComparisonPageProps {
-  searchParams: Record<string, string | string[] | undefined>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 async function fetchComparison(ids: string) {
@@ -50,9 +50,10 @@ async function fetchDefaultComparisonProducts(
 }
 
 export default async function ComparisonPage({ searchParams }: ComparisonPageProps) {
-  const ids = Array.isArray(searchParams.ids)
-    ? searchParams.ids.join(",")
-    : searchParams.ids ?? "";
+  const resolvedSearchParams = await searchParams;
+  const ids = Array.isArray(resolvedSearchParams.ids)
+    ? resolvedSearchParams.ids.join(",")
+    : resolvedSearchParams.ids ?? "";
 
   const trimmedIds = ids.trim();
   const defaultProducts = trimmedIds

--- a/frontend/src/app/products/[productId]/page.tsx
+++ b/frontend/src/app/products/[productId]/page.tsx
@@ -10,7 +10,7 @@ import apiClient from "@/lib/apiClient";
 import type { ProductOffersResponse, RelatedProductsResponse } from "@/types/api";
 
 interface ProductDetailPageProps {
-  params: { productId: string };
+  params: Promise<{ productId: string }>;
 }
 
 function buildComparisonHref(...productIds: number[]): string {
@@ -58,7 +58,8 @@ async function fetchRelatedProducts(productId: number, limit = 4) {
 }
 
 export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
-  const productId = Number(params.productId);
+  const resolvedParams = await params;
+  const productId = Number(resolvedParams.productId);
 
   if (Number.isNaN(productId)) {
     notFound();


### PR DESCRIPTION
## Summary
- await the comparison page search parameters before reading `ids` to satisfy Next.js dynamic routing requirements
- await the product detail route params before parsing the `productId` to prevent runtime errors when rendering

## Testing
- npm run lint *(fails: ESLint couldn't find the config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fa25c1b08325a722f5c1c0612905