### PR TITLE
Fix product image loading by removing restrictive referrer policy

### DIFF
--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -83,7 +83,6 @@ export function ProductImage({
           alt={alt}
           className="h-full w-full object-cover object-center"
           loading="lazy"
-          referrerPolicy="no-referrer"
           onError={() => setHasError(true)}
         />
       </div>


### PR DESCRIPTION
## Summary
- allow product images to load by relying on the browser default referrer policy for external sources

## Testing
- npm run build *(fails: src/App.tsx(94,10): error TS2304: Cannot find name 'PriceAlertsSection'.)*

------
https://chatgpt.com/codex/tasks/task_e_68e505bb5cb883258e7fd5d138fe7243