### PR TITLE
Improve image URL helper for multiple bundlers

### DIFF
--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import Link from "next/link";
 
 import type { ProductSummary } from "@/types/api";
-import { buildDisplayImageUrl } from "@/lib/images";
 
 function pickImageUrl(
   ...candidates: Array<string | null | undefined>
@@ -27,7 +26,7 @@ function getProductImage(product: ProductSummary): { src: string; alt: string } 
     product.image,
     product.bestDeal?.image,
   );
-  const resolvedUrl = buildDisplayImageUrl(imageUrl);
+  const resolvedUrl = imageUrl;
 
   if (!resolvedUrl) {
     return null;

--- a/frontend/src/lib/images.ts
+++ b/frontend/src/lib/images.ts
@@ -1,4 +1,103 @@
 const HTTP_PROTOCOL_REGEX = /^https?:\/\//i;
+const DEFAULT_PROXY_PATH = "/api/image-proxy";
+
+type ImportMetaWithEnv = ImportMeta & {
+  env?: Record<string, unknown>;
+};
+
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+function getProcessEnv(): Record<string, unknown> | null {
+  const globalProcess =
+    typeof globalThis !== "undefined"
+      ? (globalThis as { process?: { env?: Record<string, unknown> } }).process
+      : undefined;
+
+  if (globalProcess && typeof globalProcess.env === "object" && globalProcess.env !== null) {
+    return globalProcess.env;
+  }
+
+  return null;
+}
+
+function isNextEnvironment(): boolean {
+  const processEnv = getProcessEnv();
+
+  if (processEnv) {
+    if ("NEXT_RUNTIME" in processEnv) {
+      return true;
+    }
+
+    if ("__NEXT_PRIVATE_PREBUNDLED_REACT" in processEnv) {
+      return true;
+    }
+  }
+
+  if (typeof window !== "undefined" && typeof window === "object") {
+    return "__NEXT_DATA__" in window;
+  }
+
+  return false;
+}
+
+function getImportMetaEnv(): Record<string, unknown> | null {
+  try {
+    if (typeof import.meta === "undefined") {
+      return null;
+    }
+
+    const meta = import.meta as ImportMetaWithEnv;
+    if (meta && typeof meta.env === "object" && meta.env !== null) {
+      return meta.env;
+    }
+  } catch {
+    // Ignore environments where import.meta is not supported
+  }
+
+  return null;
+}
+
+function resolveProxyBase(): string | null {
+  const importMetaEnv = getImportMetaEnv();
+  const processEnv = getProcessEnv();
+
+  const viteProxy = pickString(
+    importMetaEnv?.["VITE_IMAGE_PROXY_URL"],
+    importMetaEnv?.["VITE_PUBLIC_IMAGE_PROXY_URL"],
+  );
+
+  if (viteProxy) {
+    return viteProxy;
+  }
+
+  const envProxy = pickString(
+    processEnv?.["NEXT_PUBLIC_IMAGE_PROXY_URL"],
+    processEnv?.["IMAGE_PROXY_URL"],
+  );
+
+  if (envProxy) {
+    return envProxy;
+  }
+
+  if (isNextEnvironment()) {
+    return DEFAULT_PROXY_PATH;
+  }
+
+  return null;
+}
 
 function ensureProtocol(url: string): string {
   if (url.startsWith("//")) {
@@ -16,8 +115,27 @@ function needsProxy(url: string): boolean {
 }
 
 function buildProxyUrl(url: string): string {
+  const proxyBase = resolveProxyBase();
+
+  if (!proxyBase) {
+    return url;
+  }
+
   const encoded = encodeURIComponent(url);
-  return `/api/image-proxy?url=${encoded}`;
+  const hasQuery = proxyBase.includes("?");
+  const separator = hasQuery && !proxyBase.endsWith("?") ? "&" : "?";
+
+  if (HTTP_PROTOCOL_REGEX.test(proxyBase) || proxyBase.startsWith("//")) {
+    const normalized = proxyBase.endsWith("/") && !proxyBase.includes("?")
+      ? proxyBase.slice(0, -1)
+      : proxyBase;
+    return `${normalized}${separator}url=${encoded}`;
+  }
+
+  const trimmed = proxyBase.replace(/^\/+|\/+$/g, "");
+  const prefixed = trimmed.length > 0 ? `/${trimmed}` : DEFAULT_PROXY_PATH;
+
+  return `${prefixed}${separator}url=${encoded}`;
 }
 
 export function buildDisplayImageUrl(


### PR DESCRIPTION
## Summary
- extend the image URL builder so it can resolve proxy bases in both Vite and Next.js contexts
- simplify `ProductCard` to rely on the raw product image URL instead of the helper

## Testing
- npm run lint *(fails: ESLint couldn't find the "next/core-web-vitals" config in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e519bbb3008325bf27f50acb0e01f9