### PR TITLE
Expose scraper images in API responses

### DIFF
--- a/services/scraper/src/scraper/collectors/amazon.py
+++ b/services/scraper/src/scraper/collectors/amazon.py
@@ -25,6 +25,9 @@ class AmazonCollector(Collector):
             link = result.css("h2 a::attr(href)").get()
             price_whole = result.css("span.a-price-whole::text").get()
             price_fraction = result.css("span.a-price-fraction::text").get()
+            image = result.css("img.s-image::attr(src)").get()
+            if image:
+                image = image.strip()
 
             if not title or not link or not price_whole:
                 continue
@@ -37,12 +40,15 @@ class AmazonCollector(Collector):
                 {
                     "name": title.strip(),
                     "brand": None,
+                    "image": image,
+                    "image_url": image,
                     "offers": [
                         {
                             "source": self.name,
                             "url": f"https://www.amazon.fr{link}",
                             "price": price,
                             "currency": "EUR",
+                            "image": image,
                         }
                     ],
                 }

--- a/services/scraper/src/scraper/collectors/myprotein.py
+++ b/services/scraper/src/scraper/collectors/myprotein.py
@@ -20,16 +20,24 @@ class MyProteinCollector(Collector):
             products = await page.evaluate(
                 """
                 () => {
-                    return Array.from(document.querySelectorAll('[data-component="product-card"]')).map(card => ({
-                        name: card.querySelector('[data-testid="product-card-name"]').innerText.trim(),
-                        brand: 'MyProtein',
-                        offers: [{
-                            source: 'myprotein',
-                            url: card.querySelector('a').href,
-                            price: parseFloat(card.querySelector('[data-testid="product-card-price"]').innerText.replace(/[^0-9,.]/g, '').replace(',', '.')),
-                            currency: 'EUR'
-                        }]
-                    }));
+                    return Array.from(document.querySelectorAll('[data-component="product-card"]')).map(card => {
+                        const imageEl = card.querySelector('img');
+                        const image = imageEl ? imageEl.src : null;
+
+                        return {
+                            name: card.querySelector('[data-testid="product-card-name"]').innerText.trim(),
+                            brand: 'MyProtein',
+                            image,
+                            image_url: image,
+                            offers: [{
+                                source: 'myprotein',
+                                url: card.querySelector('a').href,
+                                price: parseFloat(card.querySelector('[data-testid="product-card-price"]').innerText.replace(/[^0-9,.]/g, '').replace(',', '.')),
+                                currency: 'EUR',
+                                image,
+                            }]
+                        };
+                    });
                 }
                 """
             )

--- a/services/scraper/src/scraper/crud.py
+++ b/services/scraper/src/scraper/crud.py
@@ -23,6 +23,8 @@ async def upsert_product_with_offers(
             flavour=product.flavour,
             protein_per_serving_g=product.protein_per_serving_g,
             serving_size_g=product.serving_size_g,
+            image=product.image,
+            image_url=product.image_url or product.image,
         )
         session.add(existing)
         await session.flush()
@@ -30,6 +32,8 @@ async def upsert_product_with_offers(
         existing.flavour = product.flavour
         existing.protein_per_serving_g = product.protein_per_serving_g
         existing.serving_size_g = product.serving_size_g
+        existing.image = product.image or existing.image
+        existing.image_url = product.image_url or product.image or existing.image_url
 
     await _sync_offers(session, existing, product.offers)
     return existing
@@ -51,6 +55,7 @@ async def _sync_offers(
             db_offer.in_stock = offer.in_stock
             db_offer.shipping_cost = offer.shipping_cost
             db_offer.shipping_text = offer.shipping_text
+            db_offer.image = offer.image or db_offer.image
         else:
             session.add(
                 Offer(
@@ -64,6 +69,7 @@ async def _sync_offers(
                     in_stock=offer.in_stock,
                     shipping_cost=offer.shipping_cost,
                     shipping_text=offer.shipping_text,
+                    image=offer.image,
                 )
             )
 

--- a/services/scraper/src/scraper/database.py
+++ b/services/scraper/src/scraper/database.py
@@ -27,6 +27,8 @@ class Product(Base):
     flavour: Mapped[str | None] = mapped_column(String(length=255))
     protein_per_serving_g: Mapped[float | None] = mapped_column(Float)
     serving_size_g: Mapped[float | None] = mapped_column(Float)
+    image: Mapped[str | None] = mapped_column(String(length=1024))
+    image_url: Mapped[str | None] = mapped_column(String(length=1024))
     created_at: Mapped[DateTime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -53,6 +55,7 @@ class Offer(Base):
     in_stock: Mapped[bool | None] = mapped_column(Boolean, default=None)
     shipping_cost: Mapped[float | None] = mapped_column(Float)
     shipping_text: Mapped[str | None] = mapped_column(String(length=255))
+    image: Mapped[str | None] = mapped_column(String(length=1024))
     last_checked: Mapped[DateTime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )

--- a/services/scraper/src/scraper/normalization/product.py
+++ b/services/scraper/src/scraper/normalization/product.py
@@ -15,6 +15,7 @@ class NormalizedOffer:
     shipping_text: str | None = None
     protein_content_g: float | None = None
     price_per_100g_protein: float | None = None
+    image: str | None = None
 
     def compute_metrics(self, protein_per_serving: float | None) -> None:
         if self.protein_content_g:
@@ -35,6 +36,8 @@ class NormalizedProduct:
     flavour: str | None = None
     protein_per_serving_g: float | None = None
     serving_size_g: float | None = None
+    image: str | None = None
+    image_url: str | None = None
     offers: list[NormalizedOffer] = field(default_factory=list)
 
     def compute_metrics(self) -> None:
@@ -49,6 +52,8 @@ def normalize_product(raw: dict) -> NormalizedProduct:
         flavour=raw.get("flavour"),
         protein_per_serving_g=raw.get("protein_per_serving_g"),
         serving_size_g=raw.get("serving_size_g"),
+        image=raw.get("image"),
+        image_url=raw.get("image_url"),
         offers=[NormalizedOffer(**offer) for offer in raw.get("offers", [])],
     )
 

--- a/services/scraper/src/scraper/schemas.py
+++ b/services/scraper/src/scraper/schemas.py
@@ -17,6 +17,7 @@ class OfferSchema(BaseModel):
     shipping_cost: float | None
     shipping_text: str | None
     last_checked: datetime | None
+    image: str | None = None
 
     class Config:
         from_attributes = True
@@ -29,6 +30,8 @@ class ProductSchema(BaseModel):
     flavour: str | None
     protein_per_serving_g: float | None
     serving_size_g: float | None
+    image: str | None = None
+    image_url: str | None = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- store product and offer image URLs collected by the scraper service
- update Amazon and MyProtein collectors to scrape image URLs and propagate them through normalization and persistence
- expose the new image fields in the scraper API schemas for downstream consumers

## Testing
- python -m compileall services/scraper/src/scraper

------
https://chatgpt.com/codex/tasks/task_e_68e520e10ecc8325abbc1677b930c0ad