### PR TITLE
Fix hydration issues and nested links

### DIFF
--- a/frontend/src/components/DealsShowcase.tsx
+++ b/frontend/src/components/DealsShowcase.tsx
@@ -234,8 +234,9 @@ export function DealsShowcase() {
     const fetchDeals = async () => {
       setState("loading");
       try {
-        const data = await apiClient.get<DealItem[]>("/deals", {
+        const data = await apiClient.get<DealItem[]>("/compare", {
           cache: "no-store",
+          query: { limit: 9 },
         });
 
         if (!mounted) {

--- a/frontend/src/components/PriceAlertForm.tsx
+++ b/frontend/src/components/PriceAlertForm.tsx
@@ -131,7 +131,14 @@ export function PriceAlertForm({ className }: PriceAlertFormProps = {}) {
   );
 
   return (
-    <form onSubmit={handleSubmit} className={containerClassName} autoComplete="off" noValidate>
+    <form
+      onSubmit={handleSubmit}
+      className={containerClassName}
+      autoComplete="off"
+      noValidate
+      data-lpignore="true"
+      data-lastpass-icon="false"
+    >
       <div className="space-y-6">
         <div className="space-y-2">
           <label htmlFor="alert-email" className="block text-sm font-semibold text-slate-700">
@@ -159,6 +166,7 @@ export function PriceAlertForm({ className }: PriceAlertFormProps = {}) {
           <Input
             id="alert-product"
             type="text"
+            data-lpignore="true"
             data-lastpass-icon="false"
             value={formState.product}
             onChange={handleChange("product")}
@@ -178,6 +186,7 @@ export function PriceAlertForm({ className }: PriceAlertFormProps = {}) {
             inputMode="decimal"
             min="0"
             step="0.01"
+            data-lpignore="true"
             data-lastpass-icon="false"
             value={formState.priceThreshold}
             onChange={handleChange("priceThreshold")}

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -71,14 +71,17 @@ function formatBestPrice(price: ProductSummary["bestPrice"]) {
 }
 
 export function ProductCard({ product, href, footer }: ProductCardProps) {
-  const footerNode = footer && <CardFooter className="border-t border-slate-200 pt-4 text-sm text-slate-500">{footer}</CardFooter>;
+  const footerNode =
+    footer && (
+      <CardFooter className="border-t border-slate-200 pt-4 text-sm text-slate-500">{footer}</CardFooter>
+    );
 
   const productImage = getProductImage(product);
   const [imageFailed, setImageFailed] = useState(false);
   const showImage = productImage && !imageFailed;
 
-  const content = (
-    <Card className="flex h-full flex-col justify-between border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+  const bodyContent = (
+    <>
       <CardHeader className="space-y-4">
         <div className="relative overflow-hidden rounded-3xl bg-slate-50">
           <div className="flex aspect-[4/3] w-full items-center justify-center p-6">
@@ -164,22 +167,26 @@ export function ProductCard({ product, href, footer }: ProductCardProps) {
           </div>
         </dl>
       </CardContent>
-      {footerNode}
-    </Card>
+    </>
   );
 
-  if (href) {
-    return (
-      <article className="h-full">
-        <Link
-          href={href}
-          className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 focus-visible:ring-offset-2"
-        >
-          {content}
-        </Link>
-      </article>
-    );
-  }
+  const cardBody = href ? (
+    <Link
+      href={href}
+      className="flex flex-1 flex-col focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 focus-visible:ring-offset-2"
+    >
+      {bodyContent}
+    </Link>
+  ) : (
+    <div className="flex flex-1 flex-col">{bodyContent}</div>
+  );
 
-  return <article className="h-full">{content}</article>;
+  return (
+    <article className="h-full">
+      <Card className="flex h-full flex-col justify-between border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+        {cardBody}
+        {footerNode}
+      </Card>
+    </article>
+  );
 }


### PR DESCRIPTION
## Summary
- add LastPass ignore attributes on the price alert form to prevent hydration mismatches
- load highlighted deals from the existing /compare endpoint with a capped limit
- restructure product cards so the compare button is no longer nested inside the main link

## Testing
- npm run lint *(fails: ESLint couldn't find the config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68e63cbbedd4832593133e59fe560072