### PR TITLE
Refine hero layout and fix button asChild prop

### DIFF
--- a/frontend/src/components/HeroSection.tsx
+++ b/frontend/src/components/HeroSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Search } from "lucide-react";
+import { ArrowRight, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { FormEvent, useCallback, useMemo, useState } from "react";
 
@@ -43,27 +43,32 @@ export function HeroSection({ onStartComparison, onViewDeals }: HeroSectionProps
   );
 
   return (
-    <section className="relative overflow-hidden bg-white pb-24 pt-16">
-      <div className="absolute inset-x-0 top-0 -z-10 h-full bg-gradient-to-br from-orange-100 via-white to-orange-50" />
-      <div className="mx-auto grid w-full max-w-6xl items-center gap-12 px-4 sm:px-6 lg:grid-cols-[1.1fr,0.9fr]">
+    <section className="relative overflow-hidden bg-gradient-to-b from-orange-50 via-white to-white pb-24 pt-20">
+      <div className="absolute inset-x-0 top-0 -z-10 h-full bg-[radial-gradient(circle_at_top,rgba(255,176,102,0.25),transparent_55%)]" />
+      <div className="absolute left-1/2 top-16 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-orange-200/30 blur-3xl" aria-hidden />
+
+      <div className="mx-auto flex w-full max-w-5xl flex-col items-center px-4 text-center sm:px-6">
         <motion.div
           initial={{ opacity: 0, y: 32 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="space-y-8"
+          className="w-full space-y-10"
         >
-          <div className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-orange-500 shadow-sm ring-1 ring-orange-200/60 backdrop-blur">
-            Comparateur fitness
-          </div>
+          <span className="inline-flex items-center justify-center rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-orange-500 shadow-sm ring-1 ring-orange-200/60 backdrop-blur">
+            Comparateur intelligent
+          </span>
+
           <h1 className="text-4xl font-bold leading-tight text-slate-900 sm:text-5xl lg:text-6xl">
-            Trouvez les meilleurs suppléments au meilleur prix
+            Trouvez la <span className="text-orange-500">meilleure whey</span>,<br className="hidden sm:inline" /> au meilleur prix.
           </h1>
-          <p className="text-lg leading-relaxed text-slate-600">
-            Comparez les prix de vos protéines, créatines et compléments préférés sur les plus grandes marques.
-            Visualisez les économies réalisables et laissez-vous guider vers le meilleur rapport qualité/prix.
+
+          <p className="mx-auto max-w-3xl text-lg leading-relaxed text-slate-600">
+            Comparez des centaines de compléments et optimisez vos achats fitness grâce à notre comparateur intelligent.
+            Profitez d&apos;un suivi continu des prix pour dénicher l&apos;offre idéale.
           </p>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="flex flex-col gap-3 sm:flex-row">
+
+          <form onSubmit={handleSubmit} className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+            <div className="flex flex-col gap-3 rounded-full border border-orange-200/70 bg-white/80 p-2 shadow-xl shadow-orange-100/60 backdrop-blur sm:flex-row sm:items-center sm:p-2.5">
               <label htmlFor="hero-search" className="sr-only">
                 Recherche de compléments
               </label>
@@ -73,20 +78,21 @@ export function HeroSection({ onStartComparison, onViewDeals }: HeroSectionProps
                 type="search"
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
-                placeholder="Recherchez une whey par marque, objectif ou type"
+                placeholder="Ex : Whey isolat, Optimum Nutrition, créatine monohydrate"
                 aria-describedby="popular-searches"
-                className="h-14 rounded-full border-orange-200 bg-white/90 shadow-lg shadow-orange-100/50 backdrop-blur"
+                className="h-14 rounded-full border-none bg-transparent px-6 text-base text-slate-700 placeholder:text-slate-400 focus-visible:ring-orange-300"
               />
-              <Button type="submit" size="lg" className="sm:w-auto">
+              <Button type="submit" size="lg" className="w-full rounded-full sm:w-auto">
                 <Search className="mr-2 h-5 w-5" aria-hidden="true" />
                 Rechercher
               </Button>
             </div>
+
             <div
               id="popular-searches"
-              className="flex flex-wrap items-center gap-2 text-sm text-slate-500"
+              className="flex flex-wrap items-center justify-center gap-2 text-sm text-slate-500"
             >
-              <span className="mr-2 text-xs font-semibold uppercase tracking-widest text-orange-400">
+              <span className="mr-1 text-xs font-semibold uppercase tracking-widest text-orange-400">
                 Recherches populaires
               </span>
               {popularSearches.map((suggestion) => (
@@ -97,7 +103,7 @@ export function HeroSection({ onStartComparison, onViewDeals }: HeroSectionProps
                     setSearchQuery(suggestion);
                     handleSearch(suggestion);
                   }}
-                  className="rounded-full border border-white/60 bg-white/60 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur transition hover:border-orange-200 hover:bg-white hover:text-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-200"
+                  className="rounded-full border border-white/80 bg-white/80 px-4 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:border-orange-200 hover:bg-white hover:text-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-200"
                   aria-label={`Rechercher ${suggestion}`}
                 >
                   {suggestion}
@@ -105,56 +111,24 @@ export function HeroSection({ onStartComparison, onViewDeals }: HeroSectionProps
               ))}
             </div>
           </form>
-          <p className="text-sm text-slate-500">
-            +900 produits comparés · 70 marques suivies · mises à jour en continu
+
+          <p className="text-sm font-medium text-slate-500">
+            +900 produits comparés • 70 marques suivies • mises à jour 24/7
           </p>
-          <div className="flex flex-col gap-3 sm:flex-row">
-            <Button size="lg" onClick={onStartComparison} className="shadow-md">
+
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Button size="lg" onClick={onStartComparison} className="rounded-full px-8 shadow-lg">
               Lancer le comparateur
             </Button>
             <Button
               size="lg"
               variant="ghost"
               onClick={onViewDeals}
-              className="border border-slate-200"
+              className="rounded-full border border-transparent text-orange-500 hover:border-orange-200 hover:bg-orange-50"
             >
               Voir les promotions
+              <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
             </Button>
-          </div>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, x: 40 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.7, delay: 0.1 }}
-          className="relative"
-        >
-          <div className="relative overflow-hidden rounded-[2.5rem] border border-orange-100 bg-white shadow-2xl">
-            <div className="absolute -right-12 -top-12 h-48 w-48 rounded-full bg-orange-100 blur-3xl" aria-hidden />
-            <div className="space-y-6 p-8">
-              <p className="text-sm font-semibold uppercase tracking-widest text-orange-500">
-                Aperçu en temps réel
-              </p>
-              <div className="space-y-4">
-                <div className="rounded-3xl bg-orange-50 p-4">
-                  <p className="text-sm font-semibold text-orange-500">Promo flash</p>
-                  <p className="mt-1 text-lg font-bold text-slate-900">Whey Isolate 1,5kg</p>
-                  <p className="text-sm text-slate-500">-18% vs prix moyen du mois dernier</p>
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="rounded-3xl border border-slate-200/80 p-4 text-sm text-slate-600">
-                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">Prix moyen</p>
-                    <p className="mt-2 text-2xl font-bold text-slate-900">27,90 €</p>
-                    <p className="text-xs text-green-500">-2,4% cette semaine</p>
-                  </div>
-                  <div className="rounded-3xl border border-slate-200/80 p-4 text-sm text-slate-600">
-                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">Marchands suivis</p>
-                    <p className="mt-2 text-2xl font-bold text-slate-900">18</p>
-                    <p className="text-xs text-slate-400">Actualisation toutes les 2h</p>
-                  </div>
-                </div>
-              </div>
-            </div>
           </div>
         </motion.div>
       </div>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -2,6 +2,8 @@
 
 import * as React from "react";
 
+import { Slot } from "@radix-ui/react-slot";
+
 import { cn, type ClassValue } from "@/lib/utils";
 
 const baseStyles =
@@ -60,15 +62,18 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       variant = "primary",
       size = "default",
       type = "button",
+      asChild = false,
       ...props
     },
     ref,
   ) => {
+    const Component = asChild ? Slot : "button";
+
     return (
-      <button
+      <Component
         ref={ref}
-        type={type}
         className={buttonClassName({ variant, size, className })}
+        {...(!asChild && { type })}
         {...props}
       />
     );


### PR DESCRIPTION
## Summary
- redesign the hero section with a centered layout, gradient background, and updated search interactions to match the requested style while keeping existing sections
- update the button component to support the `asChild` pattern through Radix Slot so the prop no longer leaks to native elements

## Testing
- npm run lint *(fails: Invalid option '--ext' because the project uses eslint.config.js with flat config flags)*

------
https://chatgpt.com/codex/tasks/task_e_68e6424797b08325b9bd686701a94874