### PR TITLE
Fix incorrect button closing tag

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -88,7 +88,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     }
 
     return (
-      <Component
+      <button
         ref={ref}
         type={type}
         className={mergedClassName}


### PR DESCRIPTION
## Summary
- correct the JSX returned by the Button component so it renders a `<button>` element when not using `asChild`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e64676c91c8325896318b5a8c6aeb1