### PR TITLE
Adjust popular categories layout

### DIFF
--- a/frontend/src/components/PopularCategories.tsx
+++ b/frontend/src/components/PopularCategories.tsx
@@ -63,7 +63,7 @@ export function PopularCategories({ onSelectCategory }: PopularCategoriesProps) 
             Explorez les univers les plus recherchés par notre communauté et lancez un comparatif en un clic.
           </p>
         </div>
-        <div className="mt-12 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 xl:grid-cols-6">
           {cards.map(({ id, label, description, icon, iconColor, query, count, animationDelay }) => (
             <motion.button
               key={id}


### PR DESCRIPTION
## Summary
- update the popular categories grid to span six columns on extra-large screens so all cards align in a single row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65755a14083259995bae5568f8f80