### PR TITLE
Connect UI to live product data

### DIFF
--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,182 +1,284 @@
-export type ProductType = 'whey' | 'creatine';
+export type ProductType = 'whey' | 'creatine' | 'other';
+
+export interface Price {
+  amount: number | null;
+  currency: string | null;
+  formatted: string | null;
+}
+
+export interface Deal {
+  id: string;
+  title: string;
+  vendor: string;
+  price: Price;
+  totalPrice?: Price | null;
+  shippingCost?: number | null;
+  shippingText?: string | null;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  link?: string | null;
+  image?: string | null;
+  rating?: number | null;
+  reviewsCount?: number | null;
+  bestPrice: boolean;
+  isBestPrice?: boolean;
+  source: string;
+  productId?: number | null;
+  expiresAt?: string | null;
+  weightKg?: number | null;
+  pricePerKg?: number | null;
+}
 
 export interface Product {
   id: string;
   name: string;
   brand: string;
   type: ProductType;
-  imageUrl?: string;
-  imageAlt?: string;
-  price: number; // €
-  originalPrice: number; // €
-  discountRate: number; // 0-1
-  promotionEndsAt: string | null; // ISO date
+  category?: string | null;
+  flavor?: string | null;
+  imageUrl?: string | null;
+  imageAlt: string;
+  price: number | null;
+  bestPrice?: Price | null;
+  totalPrice?: Price | null;
+  bestDeal?: Deal | null;
+  offersCount: number;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  rating?: number | null;
+  reviewsCount?: number | null;
+  proteinPerEuro?: number | null;
+  proteinPerServing?: number | null;
+  servingSize?: number | null;
+  pricePerKg?: number | null;
+  bestVendor?: string | null;
   badges: string[];
-  sizeGrams: number;
-  proteinPerServing: number; // g
-  creatinePerServing?: number; // g
-  servings: number;
-  flavor: string;
-  rating: number; // 0-5
-  link?: string;
+  promotionEndsAt?: string | null;
+  link?: string | null;
 }
 
-export const products: Product[] = [
-  {
-    id: 'iso-elite-vanilla',
-    name: 'Iso Elite Vanilla',
-    brand: 'NutriFuel',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1586380837285-307d1fdfa4b4?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Sachet de whey protéine Iso Elite saveur vanille',
-    price: 39.9,
-    originalPrice: 49.9,
-    discountRate: 0.2,
-    promotionEndsAt: '2024-06-30T21:59:59.000Z',
-    badges: ['Best-seller', 'Sans lactose'],
-    sizeGrams: 900,
-    proteinPerServing: 27,
-    servings: 30,
-    flavor: 'Vanille',
-    rating: 4.6,
-    link: '#',
-  },
-  {
-    id: 'power-whey-choco',
-    name: 'Power Whey Choco',
-    brand: 'PureForce',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1547514701-42782101795d?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Pot de whey chocolat Power Whey',
-    price: 54.9,
-    originalPrice: 64.9,
-    discountRate: 0.154,
-    promotionEndsAt: '2024-07-15T21:59:59.000Z',
-    badges: ['-15 % immédiat', 'Edition limitée'],
-    sizeGrams: 2000,
-    proteinPerServing: 24,
-    servings: 66,
-    flavor: 'Chocolat',
-    rating: 4.8,
-    link: '#',
-  },
-  {
-    id: 'grass-fed-strawberry',
-    name: 'Grass-Fed Strawberry',
-    brand: 'Alpine Nutrition',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1586401100295-7a8096fd2315?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Sachet de whey Grass-Fed saveur fraise',
-    price: 44.5,
-    originalPrice: 44.5,
-    discountRate: 0,
-    promotionEndsAt: null,
-    badges: ['Lait d’herbage'],
-    sizeGrams: 1500,
-    proteinPerServing: 25,
-    servings: 50,
-    flavor: 'Fraise',
-    rating: 4.7,
-    link: '#',
-  },
-  {
-    id: 'creapure-performance',
-    name: 'Creapure Performance',
-    brand: 'PureForce',
-    type: 'creatine',
-    imageUrl:
-      'https://images.unsplash.com/photo-1585386959984-a4155223f96d?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Boîte de créatine Creapure Performance',
-    price: 24.9,
-    originalPrice: 29.9,
-    discountRate: 0.167,
-    promotionEndsAt: '2024-05-31T21:59:59.000Z',
-    badges: ['Qualité pharmaceutique'],
-    sizeGrams: 500,
-    proteinPerServing: 0,
-    creatinePerServing: 5,
-    servings: 100,
-    flavor: 'Neutre',
-    rating: 4.9,
-    link: '#',
-  },
-  {
-    id: 'micronized-creatine',
-    name: 'Micronized Creatine',
-    brand: 'NutriFuel',
-    type: 'creatine',
-    imageUrl:
-      'https://images.unsplash.com/photo-1600180758890-6f05512d4d6c?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Pot de poudre de créatine micronisée',
-    price: 18.5,
-    originalPrice: 18.5,
-    discountRate: 0,
-    promotionEndsAt: null,
-    badges: ['Micronisation avancée'],
-    sizeGrams: 300,
-    proteinPerServing: 0,
-    creatinePerServing: 5,
-    servings: 60,
-    flavor: 'Neutre',
-    rating: 4.5,
-    link: '#',
-  },
-  {
-    id: 'vegan-whey-mix',
-    name: 'Vegan Whey Mix',
-    brand: 'GreenLab',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1524592094714-0f0654e20314?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Shaker de whey végétale Vegan Whey Mix',
-    price: 32.0,
-    originalPrice: 36.0,
-    discountRate: 0.111,
-    promotionEndsAt: '2024-06-10T21:59:59.000Z',
-    badges: ['Vegan', 'Sans soja'],
-    sizeGrams: 1000,
-    proteinPerServing: 23,
-    servings: 33,
-    flavor: 'Cookies',
-    rating: 4.2,
-    link: '#',
-  },
-];
-
-export interface HighlightedDeal {
-  id: string;
-  productId: string;
-  tagline: string;
-  description: string;
-  ctaLabel: string;
+export interface RawPrice {
+  amount?: number | string | null;
+  currency?: string | null;
+  formatted?: string | null;
 }
 
-export const highlightedDeals: HighlightedDeal[] = [
-  {
-    id: 'deal-iso-elite',
-    productId: 'iso-elite-vanilla',
-    tagline: '20 % de réduction immédiate',
-    description:
-      "Iso whey filtrée à froid, idéale après l'entraînement pour une digestion rapide sans lactose.",
-    ctaLabel: 'Voir la promo',
-  },
-  {
-    id: 'deal-creapure',
-    productId: 'creapure-performance',
-    tagline: 'Créatine Creapure certifiée',
-    description:
-      "Profitez d'une remise spéciale sur la créatine Creapure, contrôlée pour une pureté maximale.",
-    ctaLabel: 'Profiter de l’offre',
-  },
-  {
-    id: 'deal-vegan-mix',
-    productId: 'vegan-whey-mix',
-    tagline: 'Pack vegan -11 %',
-    description:
-      'Formule végétale complète, enrichie en acides aminés essentiels et sans soja.',
-    ctaLabel: 'Découvrir le mélange',
-  },
-];
+export interface RawDeal {
+  id?: string | null;
+  title?: string | null;
+  vendor?: string | null;
+  price?: RawPrice | null;
+  totalPrice?: RawPrice | null;
+  shippingCost?: number | string | null;
+  shippingText?: string | null;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  link?: string | null;
+  image?: string | null;
+  rating?: number | string | null;
+  reviewsCount?: number | string | null;
+  bestPrice?: boolean | null;
+  isBestPrice?: boolean | null;
+  source?: string | null;
+  productId?: number | null;
+  expiresAt?: string | null;
+  weightKg?: number | string | null;
+  pricePerKg?: number | string | null;
+}
+
+export interface RawProduct {
+  id: number | string;
+  name: string;
+  brand?: string | null;
+  flavour?: string | null;
+  image?: string | null;
+  image_url?: string | null;
+  category?: string | null;
+  protein_per_serving_g?: number | string | null;
+  serving_size_g?: number | string | null;
+  bestPrice?: RawPrice | null;
+  totalPrice?: RawPrice | null;
+  bestDeal?: RawDeal | null;
+  offersCount?: number | string | null;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  rating?: number | string | null;
+  reviewsCount?: number | string | null;
+  proteinPerEuro?: number | string | null;
+  pricePerKg?: number | string | null;
+  bestVendor?: string | null;
+  link?: string | null;
+}
+
+export interface ProductListResponse {
+  products?: RawProduct[];
+}
+
+const parseNullableNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  const parsed = Number.parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const normalizePrice = (price?: RawPrice | null): Price | null => {
+  if (!price) {
+    return null;
+  }
+
+  return {
+    amount: parseNullableNumber(price.amount),
+    currency: typeof price.currency === 'string' ? price.currency : null,
+    formatted: typeof price.formatted === 'string' ? price.formatted : null,
+  };
+};
+
+export const normalizeDeal = (deal: RawDeal): Deal => {
+  const price = normalizePrice(deal.price) ?? { amount: null, currency: null, formatted: null };
+  const totalPrice = normalizePrice(deal.totalPrice);
+
+  const ensureId = (value?: string | null) => {
+    if (value && value.trim().length > 0) {
+      return value;
+    }
+
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      try {
+        return crypto.randomUUID();
+      } catch (error) {
+        // ignore and use fallback
+      }
+    }
+
+    return `deal-${Math.random().toString(36).slice(2, 10)}`;
+  };
+
+  return {
+    id: ensureId(deal.id),
+    title: deal.title ?? 'Offre',
+    vendor: deal.vendor ?? 'Marchand',
+    price,
+    totalPrice,
+    shippingCost: parseNullableNumber(deal.shippingCost),
+    shippingText: deal.shippingText ?? null,
+    inStock: typeof deal.inStock === 'boolean' ? deal.inStock : null,
+    stockStatus: deal.stockStatus ?? null,
+    link: deal.link ?? null,
+    image: deal.image ?? null,
+    rating: parseNullableNumber(deal.rating),
+    reviewsCount: parseNullableNumber(deal.reviewsCount),
+    bestPrice: Boolean(deal.bestPrice ?? deal.isBestPrice ?? false),
+    isBestPrice: Boolean(deal.isBestPrice ?? deal.bestPrice ?? false),
+    source: deal.source ?? 'Catalogue',
+    productId: deal.productId ?? null,
+    expiresAt: deal.expiresAt ?? null,
+    weightKg: parseNullableNumber(deal.weightKg),
+    pricePerKg: parseNullableNumber(deal.pricePerKg),
+  };
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .split(/[^A-Za-zÀ-ÖØ-öø-ÿ0-9]+/u)
+    .filter(Boolean)
+    .map((segment) => segment[0]!.toUpperCase() + segment.slice(1))
+    .join(' ');
+
+export const inferProductType = (
+  category?: string | null,
+  name?: string | null,
+  brand?: string | null,
+): ProductType => {
+  const reference = `${category ?? ''} ${name ?? ''} ${brand ?? ''}`.toLowerCase();
+
+  if (reference.includes('creatine') || reference.includes('créatine')) {
+    return 'creatine';
+  }
+
+  if (
+    reference.includes('whey') ||
+    reference.includes('isolate') ||
+    reference.includes('protéine') ||
+    reference.includes('protein')
+  ) {
+    return 'whey';
+  }
+
+  return 'other';
+};
+
+const buildBadges = (product: RawProduct, normalized: Product): string[] => {
+  const badges = new Set<string>();
+
+  if (product.category) {
+    badges.add(toTitleCase(product.category));
+  }
+
+  if (normalized.bestVendor) {
+    badges.add(normalized.bestVendor);
+  }
+
+  if (normalized.inStock === true) {
+    badges.add('En stock');
+  } else if (normalized.inStock === false) {
+    badges.add('Rupture');
+  }
+
+  return Array.from(badges).slice(0, 3);
+};
+
+export const normalizeProduct = (product: RawProduct): Product => {
+  const name = product.name?.trim() || 'Produit';
+  const brand = product.brand?.trim() || 'Marque inconnue';
+  const bestPrice = normalizePrice(product.bestPrice);
+  const totalPrice = normalizePrice(product.totalPrice);
+  const bestDeal = product.bestDeal ? normalizeDeal(product.bestDeal) : null;
+
+  const imageUrl = product.image_url ?? product.image ?? bestDeal?.image ?? null;
+  const price = totalPrice?.amount ?? bestPrice?.amount ?? null;
+  const type = inferProductType(product.category, product.name, product.brand);
+
+  const normalized: Product = {
+    id: String(product.id),
+    name,
+    brand,
+    type,
+    category: product.category ?? null,
+    flavor: product.flavour ?? null,
+    imageUrl,
+    imageAlt: `${brand} ${name}`.trim(),
+    price,
+    bestPrice,
+    totalPrice,
+    bestDeal,
+    offersCount: Number.parseInt(String(product.offersCount ?? 0), 10) || 0,
+    inStock: typeof product.inStock === 'boolean' ? product.inStock : null,
+    stockStatus: product.stockStatus ?? null,
+    rating: parseNullableNumber(product.rating),
+    reviewsCount: parseNullableNumber(product.reviewsCount),
+    proteinPerEuro: parseNullableNumber(product.proteinPerEuro),
+    proteinPerServing: parseNullableNumber(product.protein_per_serving_g),
+    servingSize: parseNullableNumber(product.serving_size_g),
+    pricePerKg: parseNullableNumber(product.pricePerKg),
+    bestVendor: product.bestVendor ?? bestDeal?.vendor ?? null,
+    badges: [],
+    promotionEndsAt: null,
+    link: product.link ?? bestDeal?.link ?? null,
+  };
+
+  normalized.badges = buildBadges(product, normalized);
+
+  return normalized;
+};
+
+export const ensurePrice = (price: Price | null | undefined, fallbackCurrency = 'EUR'): Price => ({
+  amount: price?.amount ?? null,
+  currency: price?.currency ?? fallbackCurrency,
+  formatted: price?.formatted ?? null,
+});

--- a/src/hooks/useHighlightedDeals.ts
+++ b/src/hooks/useHighlightedDeals.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { normalizeDeal, type Deal, type RawDeal } from '../data/products';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api';
+
+const fetchHighlightedDeals = async (): Promise<Deal[]> => {
+  try {
+    const response = await fetch(
+      `${API_BASE_URL.replace(/\/$/, '')}/compare?q=whey%20protein&limit=9`,
+    );
+
+    if (!response.ok) {
+      console.error('Unable to fetch highlighted deals', response.status, response.statusText);
+      return [];
+    }
+
+    const payload = (await response.json()) as unknown;
+    if (!Array.isArray(payload)) {
+      return [];
+    }
+
+    return payload
+      .filter((item): item is RawDeal => item && typeof item === 'object')
+      .map((deal) => normalizeDeal(deal))
+      .slice(0, 9);
+  } catch (error) {
+    console.error('Failed to load highlighted deals', error);
+    return [];
+  }
+};
+
+export const useHighlightedDeals = () =>
+  useQuery<Deal[]>({
+    queryKey: ['highlighted-deals'],
+    queryFn: fetchHighlightedDeals,
+    staleTime: 1000 * 60 * 10,
+  });

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,16 +1,34 @@
 import { useQuery } from '@tanstack/react-query';
 
-import type { Product } from '../data/products';
-import { products } from '../data/products';
+import {
+  normalizeProduct,
+  type Product,
+  type ProductListResponse,
+  type RawProduct,
+} from '../data/products';
 
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api';
+
+const fetchProducts = async (): Promise<Product[]> => {
+  try {
+    const response = await fetch(`${API_BASE_URL.replace(/\/$/, '')}/products?per_page=48`);
+    if (!response.ok) {
+      console.error('Unable to fetch products from API', response.status, response.statusText);
+      return [];
+    }
+
+    const payload = (await response.json()) as ProductListResponse;
+    const items = Array.isArray(payload.products) ? payload.products : [];
+    return items.map((product: RawProduct) => normalizeProduct(product));
+  } catch (error) {
+    console.error('Failed to load products', error);
+    return [];
+  }
+};
 
 export const useProducts = () =>
   useQuery<Product[]>({
     queryKey: ['products'],
-    queryFn: async () => {
-      await wait(400);
-      return products;
-    },
+    queryFn: fetchProducts,
     staleTime: 1000 * 60 * 5,
   });


### PR DESCRIPTION
## Summary
- normalize catalogue payloads and expose hooks to load products and highlighted deals from the live API instead of hardcoded fixtures
- refresh comparison, KPI, filter, and highlighted deal components so they render optional data from real offers while remaining resilient to missing fields
- remove the Python fallback catalogue to ensure the scraper service is the sole source for product, offer, and history data

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid option '--ext' because the project uses eslint.config.js flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68e6596a385c8325bc9355e696c6fc99