### PR TITLE
Connect product catalogue to live API data

### DIFF
--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,182 +1,295 @@
-export type ProductType = 'whey' | 'creatine';
+export type ProductType = 'whey' | 'creatine' | 'other';
+
+export interface Price {
+  amount: number | null;
+  currency: string | null;
+  formatted: string | null;
+}
+
+export interface Deal {
+  id: string;
+  title: string;
+  vendor: string;
+  price: Price;
+  totalPrice?: Price | null;
+  shippingCost?: number | null;
+  shippingText?: string | null;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  link?: string | null;
+  image?: string | null;
+  rating?: number | null;
+  reviewsCount?: number | null;
+  bestPrice: boolean;
+  isBestPrice?: boolean;
+  source: string;
+  productId?: number | null;
+  expiresAt?: string | null;
+  weightKg?: number | null;
+  pricePerKg?: number | null;
+}
 
 export interface Product {
   id: string;
   name: string;
   brand: string;
   type: ProductType;
-  imageUrl?: string;
-  imageAlt?: string;
-  price: number; // €
-  originalPrice: number; // €
-  discountRate: number; // 0-1
-  promotionEndsAt: string | null; // ISO date
+  category?: string | null;
+  flavor?: string | null;
+  imageUrl?: string | null;
+  imageAlt: string;
+  price: number | null;
+  bestPrice?: Price | null;
+  totalPrice?: Price | null;
+  bestDeal?: Deal | null;
+  offersCount: number;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  rating?: number | null;
+  reviewsCount?: number | null;
+  proteinPerEuro?: number | null;
+  proteinPerServing?: number | null;
+  servingSize?: number | null;
+  pricePerKg?: number | null;
+  bestVendor?: string | null;
   badges: string[];
-  sizeGrams: number;
-  proteinPerServing: number; // g
-  creatinePerServing?: number; // g
-  servings: number;
-  flavor: string;
-  rating: number; // 0-5
-  link?: string;
+  promotionEndsAt?: string | null;
+  link?: string | null;
 }
 
-export const products: Product[] = [
-  {
-    id: 'iso-elite-vanilla',
-    name: 'Iso Elite Vanilla',
-    brand: 'NutriFuel',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1586380837285-307d1fdfa4b4?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Sachet de whey protéine Iso Elite saveur vanille',
-    price: 39.9,
-    originalPrice: 49.9,
-    discountRate: 0.2,
-    promotionEndsAt: '2024-06-30T21:59:59.000Z',
-    badges: ['Best-seller', 'Sans lactose'],
-    sizeGrams: 900,
-    proteinPerServing: 27,
-    servings: 30,
-    flavor: 'Vanille',
-    rating: 4.6,
-    link: '#',
-  },
-  {
-    id: 'power-whey-choco',
-    name: 'Power Whey Choco',
-    brand: 'PureForce',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1547514701-42782101795d?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Pot de whey chocolat Power Whey',
-    price: 54.9,
-    originalPrice: 64.9,
-    discountRate: 0.154,
-    promotionEndsAt: '2024-07-15T21:59:59.000Z',
-    badges: ['-15 % immédiat', 'Edition limitée'],
-    sizeGrams: 2000,
-    proteinPerServing: 24,
-    servings: 66,
-    flavor: 'Chocolat',
-    rating: 4.8,
-    link: '#',
-  },
-  {
-    id: 'grass-fed-strawberry',
-    name: 'Grass-Fed Strawberry',
-    brand: 'Alpine Nutrition',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1586401100295-7a8096fd2315?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Sachet de whey Grass-Fed saveur fraise',
-    price: 44.5,
-    originalPrice: 44.5,
-    discountRate: 0,
-    promotionEndsAt: null,
-    badges: ['Lait d’herbage'],
-    sizeGrams: 1500,
-    proteinPerServing: 25,
-    servings: 50,
-    flavor: 'Fraise',
-    rating: 4.7,
-    link: '#',
-  },
-  {
-    id: 'creapure-performance',
-    name: 'Creapure Performance',
-    brand: 'PureForce',
-    type: 'creatine',
-    imageUrl:
-      'https://images.unsplash.com/photo-1585386959984-a4155223f96d?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Boîte de créatine Creapure Performance',
-    price: 24.9,
-    originalPrice: 29.9,
-    discountRate: 0.167,
-    promotionEndsAt: '2024-05-31T21:59:59.000Z',
-    badges: ['Qualité pharmaceutique'],
-    sizeGrams: 500,
-    proteinPerServing: 0,
-    creatinePerServing: 5,
-    servings: 100,
-    flavor: 'Neutre',
-    rating: 4.9,
-    link: '#',
-  },
-  {
-    id: 'micronized-creatine',
-    name: 'Micronized Creatine',
-    brand: 'NutriFuel',
-    type: 'creatine',
-    imageUrl:
-      'https://images.unsplash.com/photo-1600180758890-6f05512d4d6c?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Pot de poudre de créatine micronisée',
-    price: 18.5,
-    originalPrice: 18.5,
-    discountRate: 0,
-    promotionEndsAt: null,
-    badges: ['Micronisation avancée'],
-    sizeGrams: 300,
-    proteinPerServing: 0,
-    creatinePerServing: 5,
-    servings: 60,
-    flavor: 'Neutre',
-    rating: 4.5,
-    link: '#',
-  },
-  {
-    id: 'vegan-whey-mix',
-    name: 'Vegan Whey Mix',
-    brand: 'GreenLab',
-    type: 'whey',
-    imageUrl:
-      'https://images.unsplash.com/photo-1524592094714-0f0654e20314?auto=format&fit=crop&w=600&q=80',
-    imageAlt: 'Shaker de whey végétale Vegan Whey Mix',
-    price: 32.0,
-    originalPrice: 36.0,
-    discountRate: 0.111,
-    promotionEndsAt: '2024-06-10T21:59:59.000Z',
-    badges: ['Vegan', 'Sans soja'],
-    sizeGrams: 1000,
-    proteinPerServing: 23,
-    servings: 33,
-    flavor: 'Cookies',
-    rating: 4.2,
-    link: '#',
-  },
-];
-
-export interface HighlightedDeal {
-  id: string;
-  productId: string;
-  tagline: string;
-  description: string;
-  ctaLabel: string;
+export interface RawPrice {
+  amount?: number | string | null;
+  currency?: string | null;
+  formatted?: string | null;
 }
 
-export const highlightedDeals: HighlightedDeal[] = [
-  {
-    id: 'deal-iso-elite',
-    productId: 'iso-elite-vanilla',
-    tagline: '20 % de réduction immédiate',
-    description:
-      "Iso whey filtrée à froid, idéale après l'entraînement pour une digestion rapide sans lactose.",
-    ctaLabel: 'Voir la promo',
-  },
-  {
-    id: 'deal-creapure',
-    productId: 'creapure-performance',
-    tagline: 'Créatine Creapure certifiée',
-    description:
-      "Profitez d'une remise spéciale sur la créatine Creapure, contrôlée pour une pureté maximale.",
-    ctaLabel: 'Profiter de l’offre',
-  },
-  {
-    id: 'deal-vegan-mix',
-    productId: 'vegan-whey-mix',
-    tagline: 'Pack vegan -11 %',
-    description:
-      'Formule végétale complète, enrichie en acides aminés essentiels et sans soja.',
-    ctaLabel: 'Découvrir le mélange',
-  },
-];
+export interface RawDeal {
+  id?: string | null;
+  title?: string | null;
+  vendor?: string | null;
+  price?: RawPrice | null;
+  totalPrice?: RawPrice | null;
+  shippingCost?: number | string | null;
+  shippingText?: string | null;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  link?: string | null;
+  image?: string | null;
+  rating?: number | string | null;
+  reviewsCount?: number | string | null;
+  bestPrice?: boolean | null;
+  isBestPrice?: boolean | null;
+  source?: string | null;
+  productId?: number | null;
+  expiresAt?: string | null;
+  weightKg?: number | string | null;
+  pricePerKg?: number | string | null;
+}
+
+export interface RawProduct {
+  id: number | string;
+  name: string;
+  brand?: string | null;
+  flavour?: string | null;
+  image?: string | null;
+  image_url?: string | null;
+  category?: string | null;
+  protein_per_serving_g?: number | string | null;
+  serving_size_g?: number | string | null;
+  bestPrice?: RawPrice | null;
+  totalPrice?: RawPrice | null;
+  bestDeal?: RawDeal | null;
+  offersCount?: number | string | null;
+  inStock?: boolean | null;
+  stockStatus?: string | null;
+  rating?: number | string | null;
+  reviewsCount?: number | string | null;
+  proteinPerEuro?: number | string | null;
+  pricePerKg?: number | string | null;
+  bestVendor?: string | null;
+  link?: string | null;
+}
+
+export interface ProductListPagination {
+  page?: number;
+  perPage?: number;
+  total?: number;
+  totalPages?: number;
+  hasPrevious?: boolean;
+  hasNext?: boolean;
+}
+
+export interface ProductListResponse {
+  products?: RawProduct[];
+  items?: RawProduct[];
+  pagination?: ProductListPagination | null;
+}
+
+const parseNullableNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  const parsed = Number.parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const normalizePrice = (price?: RawPrice | null): Price | null => {
+  if (!price) {
+    return null;
+  }
+
+  return {
+    amount: parseNullableNumber(price.amount),
+    currency: typeof price.currency === 'string' ? price.currency : null,
+    formatted: typeof price.formatted === 'string' ? price.formatted : null,
+  };
+};
+
+export const normalizeDeal = (deal: RawDeal): Deal => {
+  const price = normalizePrice(deal.price) ?? { amount: null, currency: null, formatted: null };
+  const totalPrice = normalizePrice(deal.totalPrice);
+
+  const ensureId = (value?: string | null) => {
+    if (value && value.trim().length > 0) {
+      return value;
+    }
+
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      try {
+        return crypto.randomUUID();
+      } catch (error) {
+        // ignore and use fallback
+      }
+    }
+
+    return `deal-${Math.random().toString(36).slice(2, 10)}`;
+  };
+
+  return {
+    id: ensureId(deal.id),
+    title: deal.title ?? 'Offre',
+    vendor: deal.vendor ?? 'Marchand',
+    price,
+    totalPrice,
+    shippingCost: parseNullableNumber(deal.shippingCost),
+    shippingText: deal.shippingText ?? null,
+    inStock: typeof deal.inStock === 'boolean' ? deal.inStock : null,
+    stockStatus: deal.stockStatus ?? null,
+    link: deal.link ?? null,
+    image: deal.image ?? null,
+    rating: parseNullableNumber(deal.rating),
+    reviewsCount: parseNullableNumber(deal.reviewsCount),
+    bestPrice: Boolean(deal.bestPrice ?? deal.isBestPrice ?? false),
+    isBestPrice: Boolean(deal.isBestPrice ?? deal.bestPrice ?? false),
+    source: deal.source ?? 'Catalogue',
+    productId: deal.productId ?? null,
+    expiresAt: deal.expiresAt ?? null,
+    weightKg: parseNullableNumber(deal.weightKg),
+    pricePerKg: parseNullableNumber(deal.pricePerKg),
+  };
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .split(/[^A-Za-zÀ-ÖØ-öø-ÿ0-9]+/u)
+    .filter(Boolean)
+    .map((segment) => segment[0]!.toUpperCase() + segment.slice(1))
+    .join(' ');
+
+export const inferProductType = (
+  category?: string | null,
+  name?: string | null,
+  brand?: string | null,
+): ProductType => {
+  const reference = `${category ?? ''} ${name ?? ''} ${brand ?? ''}`.toLowerCase();
+
+  if (reference.includes('creatine') || reference.includes('créatine')) {
+    return 'creatine';
+  }
+
+  if (
+    reference.includes('whey') ||
+    reference.includes('isolate') ||
+    reference.includes('protéine') ||
+    reference.includes('protein')
+  ) {
+    return 'whey';
+  }
+
+  return 'other';
+};
+
+const buildBadges = (product: RawProduct, normalized: Product): string[] => {
+  const badges = new Set<string>();
+
+  if (product.category) {
+    badges.add(toTitleCase(product.category));
+  }
+
+  if (normalized.bestVendor) {
+    badges.add(normalized.bestVendor);
+  }
+
+  if (normalized.inStock === true) {
+    badges.add('En stock');
+  } else if (normalized.inStock === false) {
+    badges.add('Rupture');
+  }
+
+  return Array.from(badges).slice(0, 3);
+};
+
+export const normalizeProduct = (product: RawProduct): Product => {
+  const name = product.name?.trim() || 'Produit';
+  const brand = product.brand?.trim() || 'Marque inconnue';
+  const bestPrice = normalizePrice(product.bestPrice);
+  const totalPrice = normalizePrice(product.totalPrice);
+  const bestDeal = product.bestDeal ? normalizeDeal(product.bestDeal) : null;
+
+  const imageUrl = product.image_url ?? product.image ?? bestDeal?.image ?? null;
+  const price = totalPrice?.amount ?? bestPrice?.amount ?? null;
+  const type = inferProductType(product.category, product.name, product.brand);
+
+  const normalized: Product = {
+    id: String(product.id),
+    name,
+    brand,
+    type,
+    category: product.category ?? null,
+    flavor: product.flavour ?? null,
+    imageUrl,
+    imageAlt: `${brand} ${name}`.trim(),
+    price,
+    bestPrice,
+    totalPrice,
+    bestDeal,
+    offersCount: Number.parseInt(String(product.offersCount ?? 0), 10) || 0,
+    inStock: typeof product.inStock === 'boolean' ? product.inStock : null,
+    stockStatus: product.stockStatus ?? null,
+    rating: parseNullableNumber(product.rating),
+    reviewsCount: parseNullableNumber(product.reviewsCount),
+    proteinPerEuro: parseNullableNumber(product.proteinPerEuro),
+    proteinPerServing: parseNullableNumber(product.protein_per_serving_g),
+    servingSize: parseNullableNumber(product.serving_size_g),
+    pricePerKg: parseNullableNumber(product.pricePerKg),
+    bestVendor: product.bestVendor ?? bestDeal?.vendor ?? null,
+    badges: [],
+    promotionEndsAt: null,
+    link: product.link ?? bestDeal?.link ?? null,
+  };
+
+  normalized.badges = buildBadges(product, normalized);
+
+  return normalized;
+};
+
+export const ensurePrice = (price: Price | null | undefined, fallbackCurrency = 'EUR'): Price => ({
+  amount: price?.amount ?? null,
+  currency: price?.currency ?? fallbackCurrency,
+  formatted: price?.formatted ?? null,
+});

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_SERPAI_PRICE_ALERT_URL?: string;
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_DEV_API_PROXY?: string;
 }
 
 interface ImportMeta {

--- a/src/hooks/useHighlightedDeals.ts
+++ b/src/hooks/useHighlightedDeals.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { normalizeDeal, type Deal, type RawDeal } from '../data/products';
+import { fetchFromApi } from '../lib/api';
+
+const STORAGE_KEY = 'whey-comparator::highlighted-deals';
+
+const loadCachedDeals = (): Deal[] | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return undefined;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    return parsed.filter((item): item is Deal => Boolean(item && typeof item === 'object'));
+  } catch (error) {
+    console.warn('Unable to read cached highlighted deals', error);
+    return undefined;
+  }
+};
+
+const saveCachedDeals = (deals: Deal[]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(deals));
+  } catch (error) {
+    console.warn('Unable to cache highlighted deals', error);
+  }
+};
+
+const fetchHighlightedDeals = async (): Promise<Deal[]> => {
+  try {
+    const payload = (await fetchFromApi('/compare?q=whey%20protein&limit=9')) as unknown;
+    if (!Array.isArray(payload)) {
+      return [];
+    }
+
+    return payload
+      .filter((item): item is RawDeal => item && typeof item === 'object')
+      .map((deal) => normalizeDeal(deal))
+      .slice(0, 9);
+  } catch (error) {
+    console.error('Failed to load highlighted deals', error);
+    return [];
+  }
+};
+
+export const useHighlightedDeals = () => {
+  const initialData = loadCachedDeals;
+  const query = useQuery<Deal[]>({
+    queryKey: ['highlighted-deals'],
+    queryFn: fetchHighlightedDeals,
+    staleTime: 1000 * 60 * 10,
+    gcTime: 1000 * 60 * 20,
+    refetchOnWindowFocus: false,
+    placeholderData: (previousData) => previousData,
+    initialData,
+  });
+
+  useEffect(() => {
+    if (query.data && query.data.length > 0) {
+      saveCachedDeals(query.data);
+    }
+  }, [query.data]);
+
+  return query;
+};

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,16 +1,83 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
-import type { Product } from '../data/products';
-import { products } from '../data/products';
+import {
+  normalizeProduct,
+  type Product,
+  type ProductListResponse,
+  type RawProduct,
+} from '../data/products';
+import { fetchFromApi } from '../lib/api';
 
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const STORAGE_KEY = 'whey-comparator::products';
 
-export const useProducts = () =>
-  useQuery<Product[]>({
+const loadCachedProducts = (): Product[] | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return undefined;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    return parsed.filter((item): item is Product => Boolean(item && typeof item === 'object'));
+  } catch (error) {
+    console.warn('Unable to read cached products from sessionStorage', error);
+    return undefined;
+  }
+};
+
+const saveCachedProducts = (products: Product[]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(products));
+  } catch (error) {
+    console.warn('Unable to cache products in sessionStorage', error);
+  }
+};
+
+const fetchProducts = async (): Promise<Product[]> => {
+  try {
+    const payload = await fetchFromApi<ProductListResponse>('/products?per_page=48');
+    const items = Array.isArray(payload.products)
+      ? payload.products
+      : Array.isArray((payload as { items?: RawProduct[] }).items)
+        ? (payload as { items?: RawProduct[] }).items ?? []
+        : [];
+    return items.map((product: RawProduct) => normalizeProduct(product));
+  } catch (error) {
+    console.error('Failed to load products', error);
+    return [];
+  }
+};
+
+export const useProducts = () => {
+  const initialData = loadCachedProducts;
+  const query = useQuery<Product[]>({
     queryKey: ['products'],
-    queryFn: async () => {
-      await wait(400);
-      return products;
-    },
+    queryFn: fetchProducts,
     staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 15,
+    refetchOnWindowFocus: false,
+    placeholderData: (previousData) => previousData,
+    initialData,
   });
+
+  useEffect(() => {
+    if (query.data && query.data.length > 0) {
+      saveCachedProducts(query.data);
+    }
+  }, [query.data]);
+
+  return query;
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,112 @@
+const unique = <T,>(values: T[]): T[] => {
+  const seen = new Set<T>();
+  const result: T[] = [];
+  for (const value of values) {
+    if (value == null) {
+      continue;
+    }
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+};
+
+const sanitizeBase = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+};
+
+const resolveConfiguredBase = (): string | null => {
+  try {
+    const meta = import.meta as ImportMeta & {
+      env?: Record<string, string | undefined>;
+    };
+    const candidate = meta.env?.VITE_API_BASE_URL;
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  } catch (error) {
+    console.warn('Unable to read VITE_API_BASE_URL from import.meta', error);
+  }
+  return null;
+};
+
+const resolveDevApiBase = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const url = new URL(window.location.href);
+    if (!url.port) {
+      return null;
+    }
+
+    const numericPort = Number.parseInt(url.port, 10);
+    if (Number.isNaN(numericPort)) {
+      return null;
+    }
+
+    if (numericPort === 3000 || numericPort === 5173) {
+      return `${url.protocol}//${url.hostname}:8000`;
+    }
+
+    return null;
+  } catch (error) {
+    console.warn('Unable to derive API base URL from window.location', error);
+    return null;
+  }
+};
+
+const candidateBases = (): string[] => {
+  const bases: string[] = [];
+  const configured = resolveConfiguredBase();
+  if (configured) {
+    bases.push(configured);
+  }
+
+  const devBase = resolveDevApiBase();
+  if (devBase) {
+    bases.push(devBase);
+  }
+
+  bases.push('/api');
+  bases.push('');
+
+  return unique(bases.map(sanitizeBase));
+};
+
+export const buildApiUrl = (path: string, base?: string) => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const prefix = sanitizeBase(base ?? candidateBases()[0] ?? '');
+  return `${prefix}${normalizedPath}`;
+};
+
+export const fetchFromApi = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const bases = candidateBases();
+  const errors: unknown[] = [];
+
+  for (const base of bases) {
+    const url = `${base}${normalizedPath}`;
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok) {
+        errors.push(new Error(`Request failed for ${url}: ${response.status} ${response.statusText}`));
+        continue;
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      errors.push(error);
+      continue;
+    }
+  }
+
+  console.error('All API base URL candidates failed', { normalizedPath, errors });
+  throw errors[errors.length - 1] ?? new Error('Unable to reach API');
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,31 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const resolveDevApiTarget = () => {
+  const candidate = (
+    globalThis as typeof globalThis & {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env?.VITE_DEV_API_PROXY;
+
+  if (typeof candidate === 'string' && candidate.trim().length > 0) {
+    return candidate.trim();
+  }
+
+  return 'http://localhost:8000';
+};
+
+const DEV_API_TARGET = resolveDevApiTarget();
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: DEV_API_TARGET,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- fallback to SerpAPI catalogue data when the scraper has no products and surface normalized results from `/products`
- add shared API utilities plus sessionStorage caches so products and highlighted deals reuse the last payload between reloads
- configure the Vite dev proxy for `/api` to point to the FastAPI backend during local development

## Testing
- npm run build
- npm run lint *(fails: Invalid option '--ext' with eslint.config.js flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68e6596a385c8325bc9355e696c6fc99