### PR TITLE
Improve API client proxy fallback handling

### DIFF
--- a/frontend/src/app/api/proxy/route.ts
+++ b/frontend/src/app/api/proxy/route.ts
@@ -23,6 +23,7 @@ export async function GET(request: NextRequest) {
         "X-Forwarded-For": request.headers.get("x-forwarded-for") ?? undefined,
       },
       cache: "no-store",
+      allowProxyFallback: false,
     });
 
     return NextResponse.json(data);


### PR DESCRIPTION
## Summary
- add proxy preference and fallback handling to the shared API client so server-side comparison requests retry via the Next.js proxy when the upstream API is unreachable
- prevent the `/api/proxy` route from recursively calling itself by disabling proxy fallback inside the handler

## Testing
- npm run lint *(fails: ESLint can't find `next/core-web-vitals` config)*

------
https://chatgpt.com/codex/tasks/task_e_68e6724271fc8325a681c4ac83f4ecba