### PR TITLE
Add flash sale promotion section to homepage

### DIFF
--- a/frontend/src/app/HomePageClient.tsx
+++ b/frontend/src/app/HomePageClient.tsx
@@ -8,6 +8,7 @@ import { HeroSection } from "@/components/HeroSection";
 import { PopularCategories } from "@/components/PopularCategories";
 import { GymLocatorSection } from "@/components/GymLocatorSection";
 import { PriceAlertsSection } from "@/components/PriceAlertsSection";
+import { FlashSaleSection } from "@/components/FlashSaleSection";
 import { StatsSection } from "@/components/StatsSection";
 import { TestimonialsSection } from "@/components/TestimonialsSection";
 import { WhyChooseUsSection } from "@/components/WhyChooseUsSection";
@@ -38,6 +39,7 @@ export function HomePageClient() {
     <div className="bg-background text-text">
       <HeroSection onStartComparison={handleStartComparison} onViewDeals={handleViewDeals} />
       <DealsShowcase />
+      <FlashSaleSection />
       <PopularCategories onSelectCategory={handleSelectCategory} />
       <WhyChooseUsSection />
       <StatsSection />

--- a/frontend/src/components/FlashSaleSection.tsx
+++ b/frontend/src/components/FlashSaleSection.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+
+import { ProductCard } from "@/components/ProductCard";
+import { ProductCardSkeleton } from "@/components/ProductCardSkeleton";
+import { buttonClassName } from "@/components/ui/button";
+import apiClient from "@/lib/apiClient";
+import type { ProductListResponse, ProductSummary } from "@/types/api";
+
+function sortByDiscount(products: ProductSummary[]): ProductSummary[] {
+  return [...products].sort((a, b) => {
+    const discountA = typeof a.discount === "number" ? a.discount : 0;
+    const discountB = typeof b.discount === "number" ? b.discount : 0;
+    return discountB - discountA;
+  });
+}
+
+export function FlashSaleSection() {
+  const [products, setProducts] = useState<ProductSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchFlashSales() {
+      setIsLoading(true);
+      setHasError(false);
+
+      try {
+        const data = await apiClient.get<ProductListResponse>("/products", {
+          query: {
+            per_page: 20,
+            sort: "discount_desc",
+            on_sale: true,
+          },
+          cache: "no-store",
+        });
+
+        if (!isMounted) return;
+
+        const promos = (data?.products ?? []).filter(
+          (product) => typeof product.discount === "number" && product.discount > 0,
+        );
+
+        setProducts(sortByDiscount(promos).slice(0, 4));
+      } catch (error) {
+        console.error("Failed to load flash sales", error);
+        if (isMounted) {
+          setHasError(true);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchFlashSales();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const content = useMemo(() => {
+    if (isLoading) {
+      return (
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <ProductCardSkeleton key={`flash-sale-skeleton-${index}`} />
+          ))}
+        </div>
+      );
+    }
+
+    if (products.length === 0) {
+      return (
+        <p className="text-center text-muted">
+          {hasError ? "Impossible de charger les promotions." : "Aucune promotion pour le moment"}
+        </p>
+      );
+    }
+
+    return (
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        {products.map((product) => (
+          <ProductCard key={`flash-sale-${product.id}`} product={product} />
+        ))}
+      </div>
+    );
+  }, [hasError, isLoading, products]);
+
+  return (
+    <section className="relative overflow-hidden py-20">
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-accent/30 to-transparent"
+        aria-hidden
+      />
+      <div className="mx-auto w-full max-w-6xl px-4 sm:px-6">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-3">
+            <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-primary">
+              <Sparkles className="h-4 w-4" aria-hidden />
+              Vente flash
+            </div>
+            <div>
+              <h2 className="font-heading text-3xl font-semibold text-dark sm:text-4xl dark:text-white">
+                Les meilleures promos du moment
+              </h2>
+              <p className="mt-3 text-lg text-muted dark:text-text-2">
+                4 offres triées par réduction décroissante pour ne manquer aucune bonne affaire.
+              </p>
+            </div>
+          </div>
+          <Link href="/comparateur" className={buttonClassName({ variant: "outline", className: "gap-2" })}>
+            Explorer toutes les offres
+            <span aria-hidden>→</span>
+          </Link>
+        </div>
+
+        <div className="mt-10">{content}</div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new flash sale section on the homepage ahead of popular categories
- fetch discounted products via the API, sorting by reduction and showing skeletons or a fallback message

## Testing
- npm run lint --prefix frontend *(fails due to pre-existing lint warnings/errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692872f5ef1883258f832cdb2483f248)